### PR TITLE
Integrate Solid Cable (Rails 8 default)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,10 +22,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      redis:
-        image: redis
-        ports: ['6379:6379']
-        options: --entrypoint redis-server
     env:
       CI: true
       RAILS_ENV: test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Project Overview
 
-Quill is a Web3 paid-publishing platform ([quill.im](https://quill.im/)) where authors publish priced articles and readers pay to access them. Its distinguishing feature is **early reader rewards**: a share of each article's new revenue (default 40%) is distributed proportionally to readers who paid earlier. The stack is a Rails monolith with Hotwire (Turbo + Stimulus), ERB partials, PostgreSQL, Redis, and background jobs via Good Job. Integrations include Mixin Network, MVM (Ethereum L2), MixPay, Arweave permanence, and wallet login (MetaMask, Coinbase, WalletConnect).
+Quill is a Web3 paid-publishing platform ([quill.im](https://quill.im/)) where authors publish priced articles and readers pay to access them. Its distinguishing feature is **early reader rewards**: a share of each article's new revenue (default 40%) is distributed proportionally to readers who paid earlier. The stack is a Rails monolith with Hotwire (Turbo + Stimulus), ERB partials, PostgreSQL, Solid Cable, Solid Cache, and background jobs via Good Job. Integrations include Mixin Network, MVM (Ethereum L2), MixPay, Arweave permanence, and wallet login (MetaMask, Coinbase, WalletConnect).
 
 ## Tech Stack
 
@@ -13,7 +13,8 @@ Quill is a Web3 paid-publishing platform ([quill.im](https://quill.im/)) where a
 | Language | Ruby | 4.0.5 (see `.ruby-version`, `mise.toml`) |
 | Framework | Rails | 8.1.x |
 | Database | PostgreSQL | — |
-| Cache / jobs | Redis, Solid Cache, Good Job | — |
+| Real-time | Solid Cable (separate `*_cable` DB) | — |
+| Cache / jobs | Solid Cache, Good Job | — |
 | Frontend | Turbo, Stimulus, Tailwind, esbuild | Node 20+, Bun 1.x |
 | Testing | Minitest, Capybara | minitest ~> 5.25 (Ruby 4 compat) |
 | Lint | RuboCop (rails-omakase), Prettier | — |
@@ -58,7 +59,7 @@ cp config/settings.yml config/settings.local.yml       # edit host for local URL
 bin/rails db:prepare
 ```
 
-Requires PostgreSQL and Redis running locally (or via Docker). See `CONTRIBUTING.md` for credential field examples (note: README versions are authoritative over CONTRIBUTING's Ruby 3.2 note).
+Requires PostgreSQL running locally (or via Docker). See `CONTRIBUTING.md` for credential field examples (note: README versions are authoritative over CONTRIBUTING's Ruby 3.2 note).
 
 ### Run
 
@@ -110,7 +111,7 @@ bun run build:css
 - **Location**: `test/` mirrors `app/` (`test/models/`, `test/controllers/`, `test/jobs/`, `test/notifiers/`)
 - **Naming**: `*_test.rb`; fixtures in `test/fixtures/`
 - **Style**: Minitest
-- **Env**: `RAILS_ENV=test`; CI uses Postgres + Redis service containers
+- **Env**: `RAILS_ENV=test`; CI uses Postgres service container
 
 ## Common Tasks
 

--- a/Gemfile
+++ b/Gemfile
@@ -203,3 +203,5 @@ gem "mini_racer", platforms: :ruby
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 gem "dockerfile-rails", ">= 1.2", group: :development
+
+gem "solid_cable", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,11 @@ GEM
       websocket (~> 1.0)
     sha3 (1.0.5)
     simple_command (1.0.1)
+    solid_cable (3.0.12)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_cache (1.0.10)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -690,6 +695,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   selenium-webdriver (>= 4.11)
   simple_command
+  solid_cable (~> 3.0)
   solid_cache (~> 1.0)
   stimulus-rails
   tsort

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Request body example:
 
 - Ruby 4.0.5 locally (see `.ruby-version` or `mise.toml`; Docker images use `4.0.4-slim` until `4.0.5-slim` is published)
 - Rails 8.1.3
-- PostgreSQL and Redis for local/CI tests
+- PostgreSQL for local/CI tests
 - Node.js 20+ and Bun 1.x for the asset pipeline
 
 ```bash

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,20 @@
 development:
-  adapter: postgresql
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
   channel_prefix: <%= Rails.application.credentials.dig(:action_cable, :namespace) || 'quill_cable' %>
 
 test:
   adapter: test
 
 production:
-  adapter: postgresql
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
   channel_prefix: <%= Rails.application.credentials.dig(:action_cable, :namespace) || 'quill_cable' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,20 @@
-development:
+default: &default
   adapter:  postgresql
   host:     localhost
   encoding: unicode
-  database: prsdigg_development
   pool:     5
   username: postgres
   password: postgres
   template: template0
+
+development:
+  primary:
+    <<: *default
+    database: prsdigg_development
+  cable:
+    <<: *default
+    database: prsdigg_development_cable
+    migrations_paths: db/cable_migrate
 
 test:
   adapter:  postgresql
@@ -19,11 +27,16 @@ test:
   template: template0
 
 production:
-  adapter:  postgresql
-  host:     <%= ENV['DATABASE_HOST'] %>
-  encoding: unicode
-  database: <%= ENV['POSTGRES_DB'] %>
-  username: <%= ENV['POSTGRES_USER'] %>
-  password: <%= ENV['POSTGRES_PASSWORD'] %>
-  pool:     <%= ENV.fetch("RAILS_MAX_THREADS", 32) %>
-  template: template0
+  primary: &primary_production
+    adapter:  postgresql
+    host:     <%= ENV['DATABASE_HOST'] %>
+    encoding: unicode
+    database: <%= ENV['POSTGRES_DB'] %>
+    username: <%= ENV['POSTGRES_USER'] %>
+    password: <%= ENV['POSTGRES_PASSWORD'] %>
+    pool:     <%= ENV.fetch("RAILS_MAX_THREADS", 32) %>
+    template: template0
+  cable:
+    <<: *primary_production
+    database: <%= ENV.fetch('POSTGRES_CABLE_DB', "#{ENV['POSTGRES_DB']}_cable") %>
+    migrations_paths: db/cable_migrate

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -36,6 +36,7 @@ env:
     DATABASE_HOST: 'quill-db'
     POSTGRES_USER: 'postgres'
     POSTGRES_DB: 'quill_production'
+    POSTGRES_CABLE_DB: 'quill_production_cable'
   secret:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,11 @@
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "channel_hash", limit: 8, null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end


### PR DESCRIPTION
## Summary
- Add `solid_cable` with a separate cable database for dev and production
- Configure `solid_cable` in development (not `async`) so Turbo Stream broadcasts from Good Job workers reach browsers
- Add Kamal `POSTGRES_CABLE_DB` env and remove unused Redis from CI/docs

## Test plan
- [x] `bin/rails db:prepare`
- [x] `bin/rails zeitwerk:check`
- [x] `bin/rails test` (93 runs, 0 failures)
- [x] Broadcast smoke test against cable DB
- [ ] Manual dev smoke test: purchase/notification triggers live Turbo Stream update


Made with [Cursor](https://cursor.com)