### PR TITLE
[perf-improver] Use SQL sampling for Article#random_readers

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -229,7 +229,9 @@ class Article < ApplicationRecord
   end
 
   def random_readers(limit = 24)
-    readers.where(id: readers.ids.sample(limit))
+    sampled_buyer_ids = orders.select(:buyer_id).group(:buyer_id).order(Arel.sql("RANDOM()")).limit(limit)
+
+    User.where(id: sampled_buyer_ids)
   end
 
   def touch_published_at

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -70,4 +70,18 @@ class ArticleTest < ActiveSupport::TestCase
 
     assert_nil article.partial_content
   end
+
+  test "random_readers returns at most limit distinct readers" do
+    article = articles(:published_paid)
+    buyer = users(:reader_one)
+
+    with_quill_bot_stub do
+      create_buy_order!(article: article, buyer: buyer)
+    end
+
+    readers = article.random_readers(1)
+
+    assert_equal 1, readers.size
+    assert_equal buyer, readers.first
+  end
 end


### PR DESCRIPTION
🤖 **Perf Improver (local Cursor)**

## Goal

Fix `Article#random_readers` loading every reader ID into Ruby memory before sampling.

## Approach

Replace `readers.where(id: readers.ids.sample(limit))` with a bounded SQL subquery:

```ruby
sampled_buyer_ids = orders.select(:buyer_id).group(:buyer_id).order(Arel.sql("RANDOM()")).limit(limit)
User.where(id: sampled_buyer_ids)
```

PostgreSQL rejects `ORDER BY RANDOM()` on the existing `readers` association because it uses `SELECT DISTINCT`; grouping buyer IDs on `orders` avoids that constraint.

## Before / after

| | Before | After |
|---|--------|-------|
| ID materialization | All distinct reader IDs loaded into Ruby (`readers.ids`) | Only `limit` IDs returned by DB |
| Query pattern | `SELECT id …` (full set) + `SELECT * WHERE id IN (…)` | Single query with bounded subquery |
| Memory | O(readers) | O(limit) |

## Trade-offs

- Still uses `ORDER BY RANDOM()` (acceptable for small `limit`, typically 24).
- Two-step relation (orders subquery → users) vs. going through `readers` association; behavior unchanged for distinct buyers.

## Reproducibility

```bash
bin/rails test test/models/article_test.rb:74
bin/rubocop app/models/article.rb test/models/article_test.rb
```

## Test status

- `bin/rails test test/models/article_test.rb` — pass (10 runs)
- `bin/rubocop` — pass on changed files

Made with [Cursor](https://cursor.com)