### PR TITLE
Add lightweight benchmark harness for hot paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,15 @@ bin/rails zeitwerk:check
 
 CI also runs `bin/rubocop` and `bun run lint-check`.
 
+### Benchmarks
+
+```bash
+bin/benchmark                    # all hot-path scenarios (test fixtures)
+bin/benchmark article_search     # filter by scenario name
+```
+
+See `test/benchmarks/README.md` for env vars and limitations. Stdlib-only; not run in CI.
+
 ### Lint
 
 ```bash

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,10 @@ class User < ApplicationRecord
     ).uniq
   end
 
+  def owning_collection_ids
+    Collection.joins(:buy_orders).where(buy_orders: { buyer_id: id }).distinct.pluck(:uuid)
+  end
+
   def to_param
     uid
   end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] = "test"
+
+require_relative "../config/environment"
+require "active_record/fixtures"
+
+%w[
+  support/quill_bot_stub.rb
+  support/commerce_helpers.rb
+].each { |f| require_relative "../test/#{f}" }
+
+ActiveJob::Base.queue_adapter = :test
+
+require_relative "../test/benchmarks/runner"
+require_relative "../test/benchmarks/hot_paths"
+
+Benchmarks::Runner.run(filter: ARGV.first)

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -1,0 +1,43 @@
+# Benchmarks
+
+Lightweight, stdlib-only timing harness for known hot paths. Uses test fixtures so results are reproducible on any machine with a prepared test database.
+
+## Run
+
+```bash
+bin/benchmark                    # all scenarios
+bin/benchmark article_search     # name substring filter
+```
+
+Optional env vars:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `BENCHMARK_WARMUP` | 2 | Discarded iterations before measuring |
+| `BENCHMARK_ITERATIONS` | 5 | Measured iterations (mean/min/max reported) |
+
+Example:
+
+```bash
+BENCHMARK_ITERATIONS=10 bin/benchmark article_search.bought
+```
+
+## Scenarios
+
+| Name | Hot path |
+|------|----------|
+| `article_search.popularity` | Default feed (`order_by_popularity`) |
+| `article_search.bought` | Purchased-articles filter |
+| `article_search.subscribed` | Subscribed-authors filter |
+| `article.random_readers` | SQL-sampled reader avatars |
+
+## Limitations
+
+- Fixture data is small; absolute milliseconds are **not** production representative.
+- Use for **relative** before/after comparisons on the same machine (e.g. after a query optimization).
+- Not run in CI by default. A future optional smoke job with `benchmark-ips` and thresholds is out of scope for v1.
+
+## Adding scenarios
+
+1. Register in `hot_paths.rb` with `Benchmarks::Runner.register("name") { ... }`.
+2. Optional one-time setup: `Benchmarks::Runner.setup("name") { ... }` (must match a registered name).

--- a/test/benchmarks/hot_paths.rb
+++ b/test/benchmarks/hot_paths.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+Benchmarks::Runner.register("article_search.popularity") do
+  reader = users(:reader_one)
+  ArticleSearchService.call(current_user: reader).to_a
+end
+
+Benchmarks::Runner.register("article_search.bought") do
+  buyer = users(:reader_one)
+  ArticleSearchService.call(filter: "bought", current_user: buyer).to_a
+end
+
+Benchmarks::Runner.register("article_search.subscribed") do
+  reader = users(:reader_one)
+  ArticleSearchService.call(filter: "subscribed", current_user: reader).to_a
+end
+
+Benchmarks::Runner.register("article.random_readers") do
+  article = articles(:published_paid)
+  article.random_readers(24).to_a
+end
+
+Benchmarks::Runner.setup("article_search.bought") do
+  article = articles(:published_paid)
+  buyer = users(:reader_one)
+
+  with_quill_bot_stub do
+    create_buy_order!(article: article, buyer: buyer)
+  end
+end
+
+Benchmarks::Runner.setup("article_search.subscribed") do
+  reader = users(:reader_one)
+  author = users(:author)
+  reader.create_action(:subscribe, target: author) unless reader.subscribe_user?(author)
+end
+
+Benchmarks::Runner.setup("article.random_readers") do
+  article = articles(:published_paid)
+  buyer = users(:reader_one)
+
+  with_quill_bot_stub do
+    create_buy_order!(article: article, buyer: buyer) unless article.orders.exists?
+  end
+end

--- a/test/benchmarks/runner.rb
+++ b/test/benchmarks/runner.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "benchmark"
+
+module Benchmarks
+  class Context
+    include ActiveRecord::TestFixtures
+    include CommerceHelpers
+    include QuillBotStub
+
+    self.fixture_paths = [ Rails.root.join("test/fixtures") ]
+    fixtures :all
+
+    def initialize
+      setup_fixtures
+    end
+
+    def name
+      "benchmarks"
+    end
+  end
+
+  class Runner
+    Scenario = Struct.new(:name, :setup, :measure, keyword_init: true)
+
+    def self.register(name, &block)
+      scenarios << Scenario.new(name: name, setup: nil, measure: block)
+    end
+
+    def self.setup(name, &block)
+      scenario = scenarios.find { |s| s.name == name }
+      raise ArgumentError, "Unknown scenario: #{name}" unless scenario
+
+      scenario.setup = block
+    end
+
+    def self.scenarios
+      @scenarios ||= []
+    end
+
+    def self.run(filter: nil)
+      new(filter: filter).run
+    end
+
+    def initialize(filter: nil)
+      @filter = filter
+      @warmup = ENV.fetch("BENCHMARK_WARMUP", 2).to_i
+      @iterations = ENV.fetch("BENCHMARK_ITERATIONS", 5).to_i
+      @context = Context.new
+    end
+
+    def run
+      selected = self.class.scenarios
+      selected = selected.select { |s| s.name.include?(@filter) } if @filter.present?
+
+      if selected.empty?
+        warn "No scenarios matched filter: #{@filter.inspect}"
+        exit 1
+      end
+
+      puts format_header
+      selected.each { |scenario| run_scenario(scenario) }
+    end
+
+    private
+
+    def run_scenario(scenario)
+      @context.instance_eval(&scenario.setup) if scenario.setup
+
+      @warmup.times { @context.instance_eval(&scenario.measure) }
+
+      times = Array.new(@iterations) do
+        Benchmark.realtime { @context.instance_eval(&scenario.measure) }
+      end
+
+      mean_ms = (times.sum / times.size * 1000).round(1)
+      min_ms = (times.min * 1000).round(1)
+      max_ms = (times.max * 1000).round(1)
+
+      puts format("%-32s %8.1f ms  (min %6.1f, max %6.1f)", scenario.name, mean_ms, min_ms, max_ms)
+    end
+
+    def format_header
+      <<~HEADER
+
+        Benchmarks (RAILS_ENV=test, warmup=#{@warmup}, iterations=#{@iterations})
+        #{"-" * 72}
+      HEADER
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `bin/benchmark` — a stdlib-only, fixture-backed timing harness for known hot paths (implements design in https://github.com/baizhiheizi/quill/issues/1520#issuecomment-4593134881).
- Covers `ArticleSearchService` filters (`popularity`, `bought`, `subscribed`) and `Article#random_readers`.
- Documents usage in `test/benchmarks/README.md` and `AGENTS.md`.
- Fixes missing `User#owning_collection_ids` (called by the subscribed filter but undefined at runtime; discovered while wiring the subscribed benchmark scenario).

Closes #1520

## Test plan

- [x] `bin/benchmark` runs all four scenarios and prints timing table
- [x] `bin/benchmark article_search` filters by name substring
- [x] `bin/rubocop` passes on new/changed Ruby files
- [x] `bin/rails test test/services/article_search_service_test.rb` passes


Made with [Cursor](https://cursor.com)