### PR TITLE
[perf-improver] DailyStatistic distinct payer counts in SQL

### DIFF
--- a/.cursor/perf-improver/memory.md
+++ b/.cursor/perf-improver/memory.md
@@ -7,22 +7,22 @@
 
 ## build/test/perf commands
 
-Validated against `AGENTS.md`, `config/ci.rb`, and `.github/workflows/check.yml` (2026-06-01 local run).
+Validated against `AGENTS.md`, `config/ci.rb`, and `.github/workflows/check.yml` (2026-06-02 local run).
 
 | Purpose | Command | Notes |
 |---------|---------|-------|
 | Full CI locally | `bin/ci` | setup, rubocop, `bun run lint-check`, `bin/rails test`, `db:seed:replant` |
 | Tests | `bin/rails test` | Requires PostgreSQL, `RAILS_ENV=test` |
 | Zeitwerk | `bin/rails zeitwerk:check` | Also run in CI |
-| Ruby lint | `bin/rubocop` | 485 files, no offenses (2026-06-01) |
+| Ruby lint | `bin/rubocop` | daily_statistic.rb clean (2026-06-02) |
 | JS lint | `bun run lint-check` | Prettier check on `app/javascript` |
 | JS format | `bun run lint` | Prettier write |
 | Assets | `bun run build`, `bun run build:css` | |
 | Dev server | `bin/dev` | Rails + jobs + asset watch |
+| **Benchmarks** | `bin/benchmark` | All scenarios; `bin/benchmark article_search.bought` filters |
+| Benchmark docs | `test/benchmarks/README.md` | Stdlib harness merged via #1522 / issue #1520 |
 
-**Benchmarks:** None detected (`bench/`, `benchmarks/`, criterion, etc.). Issue opened proposing stdlib harness (see completed work).
-
-**Quirks:** PostgreSQL required for tests; `bin/rails db:prepare` for multi-DB (main, cable, queue). `bundle install` needed if gems missing locally.
+**Quirks:** PostgreSQL required for tests; `bin/rails db:prepare` for multi-DB (main, cable, queue). Run `bundle install` after pulling main when Gemfile.lock changes.
 
 **Ad-hoc perf check:**
 ```bash
@@ -34,18 +34,19 @@ RAILS_ENV=test bin/rails runner "require 'benchmark'; ..."
 - `Article#readers` uses `has_many :readers, -> { distinct }` — PostgreSQL rejects `ORDER BY RANDOM()` on DISTINCT selects; sample via `orders.group(:buyer_id).order(RANDOM()).limit(n)` subquery instead.
 - `random_readers` previously used `readers.ids.sample(limit)` — O(all readers) memory.
 - `ArticleSearchService#bought`: use `select(:id)` subquery instead of `.ids` — avoids materializing all bought article IDs in Ruby and drops one round-trip query.
+- `DailyStatistic#data_attributes`: `pluck(:buyer_id).uniq.count` → `distinct.count(:buyer_id)` for `paid_users_count` and `new_payers_count` — COUNT(DISTINCT) in DB instead of loading all buyer IDs into Ruby (daily job path).
 
 ## optimization backlog
 
 1. **[HIGH] `order_by_popularity` scope** — Complex join; INNER JOIN excludes articles without orders.
 2. **[MEDIUM] `ArticleSearchService#subscribed`** — Extra queries for subscribe/owning collection IDs.
 3. ~~**[MEDIUM] `ArticleSearchService#bought`** — `bought_articles.ids` → subquery.~~ Done (2026-06-01 run).
-4. **[MEDIUM] `DailyStatistic#data_attributes`** — `pluck(:buyer_id).uniq.count` → `distinct.count(:buyer_id)`.
-5. **[LOW] `author_revenue_usd` / `reader_revenue_usd`** — Ruby sum vs SQL.
+4. ~~**[MEDIUM] `DailyStatistic#data_attributes`** — distinct count in SQL.~~ Done (2026-06-02 run).
+5. **[LOW] `author_revenue_usd` / `reader_revenue_usd`** — Ruby sum vs SQL (DailyStatistic transfer sums already use SQL).
 
 ## backlog cursor
 
-Next investigate: `DailyStatistic#data_attributes` distinct count (item 4).
+Next investigate: `order_by_popularity` scope (item 1) or `ArticleSearchService#subscribed` (item 2).
 
 ## work in progress
 
@@ -56,18 +57,20 @@ _(none)_
 - **PR #1518** (2026-06-01, merged): `Article#random_readers` SQL sampling — memory O(readers) → O(limit).
 - **Run 2026-06-01 bought subquery**: `ArticleSearchService#bought` uses `select(:id)` subquery; tests pass; SQL verified in test env.
 - **Issue #1520** (2026-06-01): Proposed lightweight benchmark harness (Task 6).
+- **#1522 / `bin/benchmark`** (merged 2026-06-02): stdlib hot-path harness on main.
+- **Run 2026-06-02 DailyStatistic**: `paid_users_count` / `new_payers_count` use `distinct.count(:buyer_id)`; rubocop + job test pass.
 
 ## last task runs
 
 | Task | Last run (UTC) |
 |------|----------------|
-| 1 | 2026-06-01 12:00 |
-| 2 | 2026-06-01 12:00 |
-| 3 | 2026-06-01 14:00 |
-| 4 | 2026-06-01 12:00 |
+| 1 | 2026-06-02 12:00 |
+| 2 | 2026-06-02 12:00 |
+| 3 | 2026-06-02 12:00 |
+| 4 | 2026-06-02 12:00 |
 | 5 | 2026-06-01 14:00 |
 | 6 | 2026-06-01 14:00 |
-| 7 | 2026-06-01 14:00 |
+| 7 | 2026-06-02 12:00 |
 
 ## monthly summary — checked off by maintainer
 

--- a/app/models/daily_statistic.rb
+++ b/app/models/daily_statistic.rb
@@ -40,9 +40,9 @@ class DailyStatistic < Statistic
   def data_attributes(date)
     {
       new_users_count: User.where(created_at: date.beginning_of_day...date.end_of_day).count,
-      paid_users_count: Order.completed.where(order_type: %i[buy_article reward_article buy_collection], created_at: ...date.end_of_day).pluck(:buyer_id).uniq.count,
+      paid_users_count: Order.completed.where(order_type: %i[buy_article reward_article buy_collection], created_at: ...date.end_of_day).distinct.count(:buyer_id),
       new_payments_count: Order.completed.where(order_type: %i[buy_article reward_article buy_collection], created_at: date.beginning_of_day...date.end_of_day).count,
-      new_payers_count: Order.completed.where(order_type: %i[buy_article reward_article buy_collection], created_at: date.beginning_of_day...date.end_of_day).pluck(:buyer_id).uniq.count,
+      new_payers_count: Order.completed.where(order_type: %i[buy_article reward_article buy_collection], created_at: date.beginning_of_day...date.end_of_day).distinct.count(:buyer_id),
       new_articles_count: Article.where(published_at: date.beginning_of_day...date.end_of_day).count,
       author_revenue_total_in_usd: Transfer.joins(:currency).where(transfer_type: :author_revenue, created_at: date.beginning_of_day...date.end_of_day).sum("amount * currencies.price_usd").to_f.round(4),
       reader_revenue_total_in_usd: Transfer.joins(:currency).where(transfer_type: :reader_revenue, created_at: date.beginning_of_day...date.end_of_day).sum("amount * currencies.price_usd").to_f.round(4)


### PR DESCRIPTION
🤖 **Perf Improver (local Cursor)**

## Run summary

Full `/perf-improver` run (2026-06-02): Tasks 1, 2, 3, 4, 7. Replaced Ruby `pluck(:buyer_id).uniq.count` with SQL `distinct.count(:buyer_id)` for daily statistics payer metrics.

## Tasks completed

- **Task 1:** Re-validated commands; `bin/benchmark` runs all four hot-path scenarios on main.
- **Task 2:** Advanced backlog cursor; implemented item 4 (`DailyStatistic#data_attributes`).
- **Task 3:** Optimization in `DailyStatistic#data_attributes` for `paid_users_count` and `new_payers_count`.
- **Task 4:** No open `[perf-improver]` PRs to maintain before this run.
- **Task 7:** Monthly activity issue #1513 updated (see Run History there).

## Issues / comments

- None created this run.

## Memory sections changed

- `build/test/perf commands` — added `bin/benchmark`
- `performance notes`, `optimization backlog`, `backlog cursor`, `completed work`, `last task runs`

## Performance evidence

**Before:** `Order...pluck(:buyer_id).uniq.count` loads every matching `buyer_id` into Ruby, then deduplicates in memory.

**After:** `Order...distinct.count(:buyer_id)` emits `COUNT(DISTINCT buyer_id)` in PostgreSQL.

**Equivalence:** Verified in test env — both paths return identical counts for `paid_users_count` and `new_payers_count` scopes (fixture data: 0).

**Impact:** Daily statistics generation (`DailyStatistics::GenerateJob` / `DailyStatistic#regenerate`) runs this for all historical paid orders up to end-of-day; production row counts can be large, so avoiding full ID materialization reduces memory and DB transfer.

**Reproduce:**
```bash
RAILS_ENV=test bin/rails runner "
  date = Time.current.yesterday
  s = Order.completed.where(order_type: %i[buy_article reward_article buy_collection], created_at: ...date.end_of_day)
  puts s.pluck(:buyer_id).uniq.count
  puts s.distinct.count(:buyer_id)
"
```

## Test / lint status

- `bin/rubocop app/models/daily_statistic.rb` — pass
- `bin/rails test test/jobs/daily_statistics/generate_job_test.rb` — pass
- `bin/benchmark` — pass (harness smoke)

## Cleanup status

Worktree clean after commit; will return to `feat/benchmark-harness-1520` (START_BRANCH).

Made with [Cursor](https://cursor.com)