### PR TITLE
[repo-assist] fix: replace accessibility-review placeholder build step with real Rails server boot

### DIFF
--- a/.github/workflows/accessibility-review.lock.yml
+++ b/.github/workflows/accessibility-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"d1baa4d09f439998f1ea62d00032e151a68af3455c93e32b3a8f5e434e7c162d","body_hash":"aa6c3b485315e8419947275a2eb14ccb5574f1769116f9dbcba22dbdfe870ea5","compiler_version":"v0.79.6","strict":true,"agent_id":"claude","engine_versions":{"claude":"2.1.168"},"agent_image_runner":"[\"self-hosted\",\"linux\",\"agentic\"]"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"2b4ce7523f0ac8d8a6bee8a82ed0dac518a60ef957d74ecea6e4e623ee54b9ab","body_hash":"588a87558e26dfcf6fa3846c01cf5648448b2b0cb1b8675176b085eea8ba9e23","compiler_version":"v0.79.6","strict":true,"agent_id":"claude","engine_versions":{"claude":"2.1.168"},"agent_image_runner":"[\"self-hosted\",\"linux\",\"agentic\"]"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"5c2fe865bb4dc46e1450f6ee0d0541d759aea73a","version":"v0.79.6"},{"repo":"oven-sh/setup-bun","sha":"0c5077e51419868618aeaa5fe8019c62421857d6","version":"v2.2.0"},{"repo":"ruby/setup-ruby","sha":"afeafc3d1ab54a631816aba4c914a0081c12ff2f","version":"v1.310.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2","digest":"sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2","digest":"sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.2@sha256:ee39841d980878ebbb87592903b06d31a1af500c71525c9616f7e8e2a27041a4"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2","digest":"sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.2@sha256:2e3a717e5f19a654cd9a2263beb52012b56bcb68562ec5ae2e42f9d156b49591"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.25","digest":"sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.25@sha256:c10331ad17668ef89f38f5e356678788a40b0cd5fef96e8f92e1d9c1de47cbaa"},{"image":"ghcr.io/github/github-mcp-server:v1.1.2","digest":"sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.2@sha256:30197479d8036c7811892bc07e06f9a05c9ef3cdd79bc59f256d50647f95788c"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -465,7 +465,28 @@ jobs:
         with:
           ruby-version: '4.0.5'
       - name: Build and run app in background
-        run: "# This step should set up the runtime environment for your app, \n# including installing any necessary dependencies, and it should\n# start your app in the background (e.g., using `&` at the end of the command).\necho \"Building and running the app in background...\"\n"
+        run: |-
+          set -e
+          echo "Preparing database for the web server..."
+          RAILS_ENV=development DATABASE_HOST=localhost bin/rails db:prepare
+          echo "Seeding development database..."
+          RAILS_ENV=development DATABASE_HOST=localhost bin/rails db:seed
+          echo "Precompiling assets..."
+          RAILS_ENV=development SECRET_KEY_BASE=DUMMY bin/rails assets:precompile
+          echo "Starting Rails server on port 3000..."
+          RAILS_ENV=development bin/rails server -p 3000 -b 0.0.0.0 -d
+          echo "Waiting for server to become reachable..."
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 || echo "000")
+            if [ "$code" != "000" ] && [ "$code" != "500" ]; then
+              echo "Server is up (HTTP $code)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start within 60s"
+          cat log/development.log || true
+          exit 1
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/accessibility-review.md
+++ b/.github/workflows/accessibility-review.md
@@ -49,36 +49,44 @@ steps:
       persist-credentials: false
   - name: Build and run app in background
     run: |
-      # This step should set up the runtime environment for your app, 
-      # including installing any necessary dependencies, and it should
-      # start your app in the background (e.g., using `&` at the end of the command).
-      echo "Building and running the app in background..."
+      set -e
+      echo "Preparing database for the web server..."
+      RAILS_ENV=development DATABASE_HOST=localhost bin/rails db:prepare
+      echo "Seeding development database..."
+      RAILS_ENV=development DATABASE_HOST=localhost bin/rails db:seed
+      echo "Precompiling assets..."
+      RAILS_ENV=development SECRET_KEY_BASE=DUMMY bin/rails assets:precompile
+      echo "Starting Rails server on port 3000..."
+      RAILS_ENV=development bin/rails server -p 3000 -b 0.0.0.0 -d
+      echo "Waiting for server to become reachable..."
+      for i in $(seq 1 60); do
+        code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 || echo "000")
+        if [ "$code" != "000" ] && [ "$code" != "500" ]; then
+          echo "Server is up (HTTP $code)"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "Server failed to start within 60s"
+      cat log/development.log || true
+      exit 1
 source: githubnext/agentics/workflows/accessibility-review.md@e15e57b40918dbca11b350c55d02ab61934afa75
 ---
 
 # Accessibility Review
 
 Your name is Accessibility Review.  Your job is to review a website for accessibility best
-practices.  If you discover any accessibility problems, you should file GitHub issue(s) 
+practices.  If you discover any accessibility problems, you should file GitHub issue(s)
 with details.
 
-Our team uses the Web Content Accessibility Guidelines (WCAG) 2.2.  You may 
+Our team uses the Web Content Accessibility Guidelines (WCAG) 2.2.  You may
 refer to these as necessary by browsing to https://www.w3.org/TR/WCAG22/ using
 the WebFetch tool.  You may also search the internet using WebSearch if you need
 additional information about WCAG 2.2.
 
 The code of the application has been checked out to the current working directory.
 
-Steps:
-
-0. Read the markdown corresponding to the workflow file under `.github/workflows/accessibility-review.md`. 
-If the section "Build and run app in background" already contains actual commands, then go to the next step. If it 
-still contains a placeholder, then:  
-   a. Work how to replace it with the actual commands to set up the runtime, install dependencies, build the project and run it in the background, e.g., using `&` at the end of the command.
-   b. Don't actually make the changes (since you're not allowed to make changes under .github/workflows), but rather create a discussion showing the exact changes that are needed to the workflow file. Do this by using a markdown codeblock to copy-and-paste into the file, plus a deep link to GitHub to the range of the file to replace.
-   c. In the discussion body mention that the user must (1) make these changes manually and (2) then run "gh aw compile" to compile the workflow file using GitHub Agentic Workflows (https://github.com/github/gh-aw).
-   d. Also instruct them to remove this section from the markdown. 
-   e. Exit the workflow with a message saying that the workflow file needs to be updated.
+## Steps
 
 1. Use the Playwright MCP tool to browse to `localhost:3000`. Review the website for accessibility problems by navigating around, clicking
   links, pressing keys, taking snapshots and/or screenshots to review, etc. using the appropriate Playwright MCP commands.
@@ -89,3 +97,4 @@ still contains a placeholder, then:
    - A clear description of the problem
    - References to the appropriate section(s) of WCAG 2.2 that are violated
    - Any relevant code snippets that illustrate the issue
+


### PR DESCRIPTION
The 'Build and run app in background' step in .github/workflows/accessibility-review.md
only echoed a message, so the workflow could never reach the Playwright browsing
phase. The accessibility-review agent has been filing the same 'manual update
required' discussion three runs in a row (#1652, #1630, #1599) before reaching
the actual review work.

Replace the placeholder with concrete commands derived from the proposal in
discussion #1652 (broadly agreed across the three runs):

- Switch from test env (set by shared/runtime.md) to RAILS_ENV=development
- Run db:prepare + db:seed against the existing PostgreSQL service
- Precompile assets so the Playwright snapshot reflects production-style markup
- Daemonize Puma on 0.0.0.0:3000
- Poll http://localhost:3000 (up to 60s) and surface log/development.log on
  failure

Drop the meta 'Step 0' from the body (it was the agent's instruction to detect
this placeholder and file the same discussion again). Steps 1-3 (the actual
accessibility review) are kept.

Recompile via 'gh aw compile' to regenerate the lock file. Test status:
'gh aw compile accessibility-review' → 0 errors, 0 warnings; lock file diff
shows the placeholder run: block replaced with the new commands.

Refs discussion #1652, #1630, #1599; closes #1659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
