### PR TITLE
Fix article show crash when Twitter username is invalid

### DIFF
--- a/app/models/concerns/users/statable.rb
+++ b/app/models/concerns/users/statable.rb
@@ -108,15 +108,28 @@ module Users::Statable
     @faucet_bonus = bonuses.find_by(asset_id: Currency::XIN_ASSET_ID, title: "Faucet")
   end
 
+  def twitter_username
+    raw = twitter_authorization&.raw
+    return unless raw.is_a?(Hash)
+
+    username = raw["username"].presence || raw["screen_name"].presence
+    return unless username.is_a?(String) || username.is_a?(Symbol)
+
+    username.to_s.strip.delete_prefix("@").presence
+  end
+
   def twitter_connected?
-    twitter_authorization.present?
+    twitter_username.present?
   end
 
   def twitter_profile_url
+    username = twitter_username
+    return if username.blank?
+
     Addressable::URI.new(
       scheme: "https",
       host: "twitter.com",
-      path: twitter_authorization&.raw&.[]("username")
+      path: "/#{username}"
     ).to_s
   end
 end

--- a/app/views/dashboard/settings/_profile.html.erb
+++ b/app/views/dashboard/settings/_profile.html.erb
@@ -28,11 +28,11 @@
   </div>
 
   <div class="overflow-x-scroll scrollbar-hide py-2 border-b border-base-content/10">
-    <% if current_user.twitter_authorization.present? %>
+    <% if current_user.twitter_connected? %>
       <span class="">
-        @<%= current_user.twitter_authorization.raw['username'] %>
+        @<%= current_user.twitter_username %>
       </span>
-      <%= link_to current_user.twitter_profile_url, 
+      <%= link_to current_user.twitter_profile_url,
         class: "ml-2",
         target: "_blank" do %>
         <%= inline_svg_tag 'icons/external-link.svg', class: 'w-4 h-4 text-blue-500 inline' %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -160,4 +160,40 @@ class UserTest < ActiveSupport::TestCase
     assert_includes rows.map(&:id), users(:reader_one).id
     assert_equal 0.0, rows.find { |u| u.id == users(:reader_one).id }.attributes["revenue_total"].to_f
   end
+
+  test "twitter_connected requires a usable username" do
+    user = users(:author)
+    user.user_authorizations.create!(
+      provider: :twitter,
+      uid: "twitter-user-id",
+      raw: { "id" => "twitter-user-id", "name" => "Author" }
+    )
+
+    assert_not user.twitter_connected?
+    assert_nil user.twitter_profile_url
+  end
+
+  test "twitter_profile_url builds a profile link from stored username" do
+    user = users(:reader_one)
+    user.user_authorizations.create!(
+      provider: :twitter,
+      uid: "reader-twitter-id",
+      raw: { "id" => "reader-twitter-id", "username" => "reader_one" }
+    )
+
+    assert user.twitter_connected?
+    assert_equal "https://twitter.com/reader_one", user.twitter_profile_url
+  end
+
+  test "twitter_profile_url ignores malformed username values" do
+    user = users(:reader_two)
+    user.user_authorizations.create!(
+      provider: :twitter,
+      uid: "reader-two-twitter-id",
+      raw: { "id" => "reader-two-twitter-id", "username" => 123 }
+    )
+
+    assert_not user.twitter_connected?
+    assert_nil user.twitter_profile_url
+  end
 end


### PR DESCRIPTION
## Summary
- Harden `twitter_username`, `twitter_connected?`, and `twitter_profile_url` against missing or malformed `raw["username"]` values
- Align dashboard Twitter settings with the same connected-state checks
- Add model tests for missing, valid, and malformed username data

## Test plan
- [x] `bin/rails test test/models/user_test.rb -n /twitter/`
- [ ] Open an article whose author has a Twitter authorization with missing/invalid username and confirm the page renders
- [ ] Confirm dashboard Twitter settings still show the profile link for valid connections


Made with [Cursor](https://cursor.com)