### PR TITLE
Replace dead Multiavatar fallback with frontend initials avatars

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module UserHelper
+  def avatar_initials(name)
+    return "?" if name.blank?
+
+    tokens = name.strip.split(/\s+/).reject(&:blank?)
+    return "?" if tokens.empty?
+
+    tokens.first(2).map { |token| token.each_grapheme_cluster.first }.join.upcase
+  end
+end

--- a/app/javascript/controllers/avatar_controller.js
+++ b/app/javascript/controllers/avatar_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus";
+import { colorFromSeed } from "../utils/avatar";
+
+export default class extends Controller {
+  static values = {
+    seed: String,
+  };
+
+  connect() {
+    this.element.style.backgroundColor = colorFromSeed(this.seedValue);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application";
 import ArticleFormController from "./article_form_controller";
 application.register("article-form", ArticleFormController);
 
+import AvatarController from "./avatar_controller";
+application.register("avatar", AvatarController);
+
 import AutoHideController from "./auto_hide_controller";
 application.register("auto-hide", AutoHideController);
 

--- a/app/javascript/controllers/references_select_controller.js
+++ b/app/javascript/controllers/references_select_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { get } from "@rails/request.js";
 import TomSelect from "tom-select";
+import { renderAvatarHtml } from "../utils/avatar";
 
 export default class extends Controller {
   static values = {
@@ -20,19 +21,33 @@ export default class extends Controller {
       render: {
         option: (option, escape) => {
           return `<div class="flex items-center space-x-2">
-              <img src="${option.author.avatar}" class="h-6 w-6 rounded-full my-0" style="margin: 0" />
-              <span>${option.title}</span>
+              ${this.authorAvatarMarkup(option.author)}
+              <span>${escape(option.title)}</span>
             </div>
             `;
         },
         item: (item, escape) => {
           return `<div class="flex items-center space-x-2 w-full">
-              <img src="${item.author.avatar}" class="inline-block h-6 w-6 rounded-full my-0" style="margin: 0" />
-              <span class="inline-block">${item.title}</span>
+              ${this.authorAvatarMarkup(item.author)}
+              <span class="inline-block">${escape(item.title)}</span>
             </div>
             `;
         },
       },
+    });
+  }
+
+  authorAvatarMarkup(author) {
+    const className = "h-6 w-6 rounded-full my-0";
+
+    if (author.avatar) {
+      return `<img src="${author.avatar}" class="${className}" style="margin: 0" />`;
+    }
+
+    return renderAvatarHtml({
+      seed: author.avatar_seed,
+      name: author.name,
+      className,
     });
   }
 

--- a/app/javascript/utils/avatar.js
+++ b/app/javascript/utils/avatar.js
@@ -1,0 +1,61 @@
+function fnv1aHash(str) {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function firstGrapheme(text) {
+  if (!text) return "";
+  const str = text.trim();
+  if (!str) return "";
+
+  if (typeof Intl !== "undefined" && Intl.Segmenter) {
+    const segmenter = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    });
+    const segments = [...segmenter.segment(str)];
+    return segments[0]?.segment || str[0];
+  }
+
+  return [...str][0] || str[0];
+}
+
+export function initials(name) {
+  if (!name) return "?";
+
+  const tokens = name.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return "?";
+
+  return tokens
+    .slice(0, 2)
+    .map((token) => {
+      const grapheme = firstGrapheme(token);
+      return /^\p{Script=Latin}$/u.test(grapheme)
+        ? grapheme.toUpperCase()
+        : grapheme;
+    })
+    .join("");
+}
+
+export function colorFromSeed(seed) {
+  const hue = fnv1aHash(String(seed || "")) % 360;
+  return `hsl(${hue}, 65%, 45%)`;
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function renderAvatarHtml({ seed, name, className = "" }) {
+  const bg = colorFromSeed(seed);
+  const text = escapeHtml(initials(name));
+
+  return `<div class="inline-flex items-center justify-center rounded-full text-white font-medium shrink-0 ${className}" style="background-color: ${bg}; margin: 0">${text}</div>`;
+}

--- a/app/javascript/utils/index.js
+++ b/app/javascript/utils/index.js
@@ -1,2 +1,3 @@
+export * from "./avatar";
 export * from "./toast";
 export * from "./notify";

--- a/app/models/mixin_network_user.rb
+++ b/app/models/mixin_network_user.rb
@@ -117,11 +117,7 @@ class MixinNetworkUser < ApplicationRecord
   end
 
   def avatar
-    raw["avatar_url"].presence || generated_avatar_url
-  end
-
-  def generated_avatar_url
-    format("https://api.multiavatar.com/%<mixin_uuid>s.svg", mixin_uuid: uuid)
+    raw["avatar_url"].presence || User.default_avatar_url
   end
 
   def ready?

--- a/app/models/nft_collection.rb
+++ b/app/models/nft_collection.rb
@@ -26,6 +26,6 @@ class NftCollection < ApplicationRecord
   validates :raw, presence: true
 
   def icon_url
-    icon&.dig("url") || format("https://api.multiavatar.com/%<uuid>s.png", uuid:)
+    icon&.dig("url") || User.default_avatar_url
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,28 +121,36 @@ class User < ApplicationRecord
     @wallet_id = (wallet.presence || create_wallet)&.uuid
   end
 
-  def avatar_url
-    @avatar_url =
+  def avatar_image_url
+    @avatar_image_url =
       if avatar.attached?
         [ Settings.storage.endpoint, avatar.key ].join("/")
       else
-        authorization.avatar_url.presence || generated_avatar_url
+        authorization&.avatar_url.presence
       end
   end
 
-  def avatar_thumb
-    @avatar_thumb =
+  def avatar_image_thumb
+    @avatar_image_thumb =
       if avatar.attached?
         [ Settings.storage.endpoint, avatar.variant(:thumb).processed.key ].join("/")
       else
-        authorization.raw&.[]("avatar_url").presence&.gsub(/s256\Z/, "s64") || generated_avatar_url
+        authorization&.raw&.[]("avatar_url").presence&.gsub(/s256\Z/, "s64")
       end
   rescue StandardError
-    avatar_url
+    avatar_image_url
   end
 
-  def generated_avatar_url
-    format("https://api.multiavatar.com/%<mixin_uuid>s.png", mixin_uuid:)
+  def avatar_url
+    avatar_image_url || self.class.default_avatar_url
+  end
+
+  def avatar_thumb
+    avatar_image_thumb || self.class.default_avatar_url
+  end
+
+  def self.default_avatar_url
+    ActionController::Base.helpers.asset_url(Settings.icon_file || "icon.png")
   end
 
   def prepare

--- a/app/views/admin/users/_field.html.erb
+++ b/app/views/admin/users/_field.html.erb
@@ -3,7 +3,7 @@
 <%= link_to admin_user_path(user, tab: tab), 
   class: "flex items-center space-x-2", 
   data: { turbo_frame: "_top" } do %>
-  <%= image_tag user.avatar_thumb, class: 'w-10 h-10 rounded-full', loading: 'lazy' %>
+  <%= render "shared/avatar", user:, thumb: true, class: "w-10 h-10 rounded-full" %>
   <div>
     <div class="truncate max-w-24"><%= user.name %></div>
     <div class="text-sm opacity-70">@<%= user.short_uid %></div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class="bg-base-100 rounded-lg p-4 shadow">
   <div class="flex items-center space-x-2 mb-4">
-    <%= image_tag @user.avatar_thumb, class: "w-12 h-12 rounded-full", lazy: true %>
+    <%= render "shared/avatar", user: @user, thumb: true, class: "w-12 h-12 rounded-full" %>
     <div>
       <div><%= @user.name %></div>
       <div class="text-sm opacity-70"><%= @user.uid %></div>

--- a/app/views/api/articles/index.json.jbuilder
+++ b/app/views/api/articles/index.json.jbuilder
@@ -20,6 +20,8 @@ json.array! @articles do |article|
 
   json.author do
     json.name article.author.name
-    json.avatar article.author.avatar_url
+    json.avatar article.author.avatar_image_url
+    json.avatar_seed article.author.mixin_uuid
+    json.avatar_initials avatar_initials(article.author.name)
   end
 end

--- a/app/views/api/articles/show.json.jbuilder
+++ b/app/views/api/articles/show.json.jbuilder
@@ -6,7 +6,9 @@ json.currency @article.currency.symbol
 json.original_url format("%<host>s/articles/%<uuid>s", host: Settings.host, uuid: @article.uuid)
 json.author do
   json.name @article.author.name
-  json.avatar @article.author.avatar_url
+  json.avatar @article.author.avatar_image_url
+  json.avatar_seed @article.author.mixin_uuid
+  json.avatar_initials avatar_initials(@article.author.name)
 end
 
 json.content @article.content_body if @article.authorized?(current_user)

--- a/app/views/article_references/_form.html.erb
+++ b/app/views/article_references/_form.html.erb
@@ -14,7 +14,18 @@
           data: {
             controller: "references-select",
             references_select_items_value: article.references.pluck(:id),
-            references_select_options_value: current_user.available_articles.collect { |a| { id: a.id, title: a.title, author: { name: a.author.name, avatar: a.author.avatar_url}} }, 
+            references_select_options_value: current_user.available_articles.collect { |a|
+              {
+                id: a.id,
+                title: a.title,
+                author: {
+                  name: a.author.name,
+                  avatar: a.author.avatar_image_url,
+                  avatar_seed: a.author.mixin_uuid,
+                  avatar_initials: avatar_initials(a.author.name)
+                }
+              }
+            },
             action: "change->article-form#touchDirty"
           }, 
           class: "focus:ring-blue-500 focus:border-blue-500 flex-1 block w-full rounded" 

--- a/app/views/article_references/index.json.jbuilder
+++ b/app/views/article_references/index.json.jbuilder
@@ -5,6 +5,8 @@ json.array! @articles do |article|
   json.title article.title
   json.author do
     json.name article.author.name
-    json.avatar article.author.avatar_url
+    json.avatar article.author.avatar_image_url
+    json.avatar_seed article.author.mixin_uuid
+    json.avatar_initials avatar_initials(article.author.name)
   end
 end

--- a/app/views/articles/_buyers.html.erb
+++ b/app/views/articles/_buyers.html.erb
@@ -16,7 +16,7 @@
       <% article.readers.sample(24).each do |reader| %>
         <div class="avatar tooltip" data-tip="<%= reader.name %>">
           <div class="w-8 h-8 sm:w-10 sm:h-10 rounded-full ring-2 ring-base-100 hover:ring-primary transition-all cursor-pointer">
-            <%= image_tag reader.avatar_thumb, class: "rounded-full" %>
+            <%= render "shared/avatar", user: reader, thumb: true, class: "rounded-full" %>
           </div>
         </div>
       <% end %>

--- a/app/views/articles/_card.html.erb
+++ b/app/views/articles/_card.html.erb
@@ -3,7 +3,7 @@
     <div class="flex items-center space-x-2">
       <div class="avatar flex-shrink-0">
         <div class="size-6 rounded-full">
-          <%= image_tag article.author.avatar_thumb, class: 'rounded-full block' %>
+          <%= render "shared/avatar", user: article.author, thumb: true, class: "rounded-full block" %>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row sm:items-center text-sm">

--- a/app/views/articles/_edit_form.html.erb
+++ b/app/views/articles/_edit_form.html.erb
@@ -74,7 +74,7 @@
           tabindex: "-1" do %>
           <div class="avatar <%= from_mixin_messenger? ? 'mr-16' : '' %>">
             <div class="size-8 rounded-full">
-              <%= image_tag current_user.avatar_thumb, class: "rounded-full" %>
+              <%= render "shared/avatar", user: current_user, thumb: true, class: "rounded-full" %>
             </div>
           </div>
         <% end %>

--- a/app/views/articles/_floating_bar.html.erb
+++ b/app/views/articles/_floating_bar.html.erb
@@ -47,7 +47,7 @@
       <% end %>
     </div>
     <% if article.author == user %>
-      <%= image_tag user.avatar_thumb, class: "w-8 h-8 rounded-full" %>
+      <%= render "shared/avatar", user:, thumb: true, class: "w-8 h-8 rounded-full" %>
     <% elsif article.authorized? user %> 
       <%= render "articles/reward_article_button", article: article, size: 'sm' %>
     <% else %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -27,7 +27,7 @@
     <div class="flex items-center space-x-3 my-6">
       <div class="avatar">
         <div class="w-10 h-10 rounded-full">
-          <%= image_tag current_user.avatar_thumb %>
+          <%= render "shared/avatar", user: current_user, thumb: true, class: "rounded-full" %>
         </div>
       </div>
       <div>

--- a/app/views/articles/_header.html.erb
+++ b/app/views/articles/_header.html.erb
@@ -10,7 +10,7 @@
   <div class="relative flex items-center space-x-2 truncate">
     <div class="avatar">
       <div class="size-10 rounded-full">
-        <%= image_tag article.author.avatar_thumb, class: "rounded-full" %>
+        <%= render "shared/avatar", user: article.author, thumb: true, class: "rounded-full" %>
       </div>
     </div>
     <div class="leading-4 truncate">

--- a/app/views/articles/_references_card.html.erb
+++ b/app/views/articles/_references_card.html.erb
@@ -9,7 +9,7 @@
       }, 
       class: "flex items-center space-x-2 mb-4" do %>
       <div class="flex flex-1 items-center space-x-2 truncate">
-        <%= image_tag reference.reference.author.avatar_thumb, class: "w-9 h-9 rounded-full" %>
+        <%= render "shared/avatar", user: reference.reference.author, thumb: true, class: "w-9 h-9 rounded-full" %>
         <span class="truncate"><%= reference.reference.title %></span>
       </div>
       <div class="text-sm">

--- a/app/views/articles/_related_articles_card.html.erb
+++ b/app/views/articles/_related_articles_card.html.erb
@@ -6,7 +6,7 @@
     <%= link_to user_article_path(article.author, article), 
       data: { controller: 'prefetch' }, 
       class: "flex items-center space-x-2 mb-4" do %>
-      <%= image_tag article.author.avatar_thumb, class: "w-9 h-9 rounded-full" %>
+      <%= render "shared/avatar", user: article.author, thumb: true, class: "w-9 h-9 rounded-full" %>
       <span class="truncate"><%= article.title %></span>
     <% end %>
   <% end %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -26,7 +26,7 @@
           tabindex: "-1" do %>
           <div class="avatar <%= from_mixin_messenger? ? 'mr-16' : '' %>">
             <div class="size-8 rounded-full">
-              <%= image_tag current_user.avatar_thumb, class: "rounded-full" %>
+              <%= render "shared/avatar", user: current_user, thumb: true, class: "rounded-full" %>
             </div>
           </div>
         <% end %>

--- a/app/views/collections/_detail.html.erb
+++ b/app/views/collections/_detail.html.erb
@@ -16,7 +16,7 @@
 <div class="flex items-center space-x-2 w-36 mb-6">
   <div class="avatar">
     <div class="size-10 rounded-full">
-      <%= image_tag collection.author.avatar_thumb, class: "rounded-full" %>
+      <%= render "shared/avatar", user: collection.author, thumb: true, class: "rounded-full" %>
     </div>
   </div>
   <div class="truncate">

--- a/app/views/collections/subscribers/_subscriber.html.erb
+++ b/app/views/collections/subscribers/_subscriber.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id @collection %>_subscriber_<%= dom_id subscriber %>" class="bg-base-100 sm:rounded-lg relative flex items-center py-2 justify-between mb-4">
   <%= link_to user_path(subscriber), class: "flex items-center space-x-2 truncate", data: { controller: 'prefetch', turbo_frame: "_top" } do %>
-    <%= image_tag subscriber.avatar_thumb, class: "w-10 h-10 rounded-full" %>
+    <%= render "shared/avatar", user: subscriber, thumb: true, class: "w-10 h-10 rounded-full" %>
     <span class="truncate max-w-24"><%= subscriber.name %></span>
   <% end %>
   <div class="">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -7,7 +7,7 @@
         turbo_frame: "_top" 
       } do %>
       <div class="size-9 rounded-full">
-        <%= image_tag comment.author.avatar_thumb, class: "rounded-full" %>
+        <%= render "shared/avatar", user: comment.author, thumb: true, class: "rounded-full" %>
       </div>
     <% end %>
     <div class="">

--- a/app/views/comments/_quote_comment.html.erb
+++ b/app/views/comments/_quote_comment.html.erb
@@ -7,7 +7,7 @@
         turbo_frame: "_top" 
       } do %>
       <div class="size-9 rounded-full">
-        <%= image_tag quote_comment.author.avatar_thumb, class: "rounded-full" %>
+        <%= render "shared/avatar", user: quote_comment.author, thumb: true, class: "rounded-full" %>
       </div>
     <% end %>
     <div class="">

--- a/app/views/dashboard/block_users/_user.html.erb
+++ b/app/views/dashboard/block_users/_user.html.erb
@@ -1,6 +1,6 @@
 <div id="block_user_<%= dom_id user %>" class="relative flex items-center py-4 border-b border-base-content/10 justify-between">
   <%= link_to user_path(user), class: "flex items-center space-x-2", data: { turbo_frame: "_top" } do %>
-    <%= image_tag user.avatar_thumb, class: "w-8 h-8 rounded-full" %>
+    <%= render "shared/avatar", user:, thumb: true, class: "w-8 h-8 rounded-full" %>
     <span class="truncate max-w-24"><%= user.name %></span>
   <% end %>
   <div class="">

--- a/app/views/dashboard/comments/_article_comment.html.erb
+++ b/app/views/dashboard/comments/_article_comment.html.erb
@@ -1,7 +1,7 @@
 <div class="py-4 border-b border-base-content/10">
   <div class="flex items-center justify-between space-x-4">
     <div class="flex items-center space-x-2">
-      <%= image_tag comment.author.avatar_thumb, class: "w-8 h-8 rounded-full", loading: :lazy %>
+      <%= render "shared/avatar", user: comment.author, thumb: true, class: "w-8 h-8 rounded-full" %>
       <div class="truncate max-w-24">
         <%= comment.author.name %>
       </div>

--- a/app/views/dashboard/orders/_article_order.html.erb
+++ b/app/views/dashboard/orders/_article_order.html.erb
@@ -5,7 +5,7 @@
     <% else %>
       <div class="flex items-center space-x-2">
         <div class="w-6">
-          <%= image_tag order.buyer.avatar_thumb, class: "w-6 h-6 rounded-full inline-block" %>
+          <%= render "shared/avatar", user: order.buyer, thumb: true, class: "w-6 h-6 rounded-full inline-block" %>
         </div>
         <span class="max-w-24 truncate whitespace-nowrap">
           <%= order.buyer.name %>

--- a/app/views/dashboard/profile_settings/_avatar_field.html.erb
+++ b/app/views/dashboard/profile_settings/_avatar_field.html.erb
@@ -11,5 +11,5 @@
     class: "btn btn-primary rounded-full" %>
 </div>
 <div class="">
-  <%= image_tag current_user.avatar_url, class: "w-16 h-16 rounded-full", loading: :lazy %>
+  <%= render "shared/avatar", user: current_user, class: "w-16 h-16 rounded-full" %>
 </div>

--- a/app/views/dashboard/profile_settings/edit.html.erb
+++ b/app/views/dashboard/profile_settings/edit.html.erb
@@ -14,7 +14,7 @@
       <div data-controller="preview-upload" class="flex items-center">
         <img data-preview-upload-target="imageTpl" class="hidden w-16 h-16 rounded-full" %>
         <div data-preview-upload-target="output" class="w-16 mr-4">
-          <%= image_tag current_user.avatar_url, class: "w-16 h-16 rounded-full", loading: :lazy %>
+          <%= render "shared/avatar", user: current_user, class: "w-16 h-16 rounded-full" %>
         </div>
         <%= form.file_field :avatar, 
           placeholder: '', 

--- a/app/views/dashboard/published_articles/_form.html.erb
+++ b/app/views/dashboard/published_articles/_form.html.erb
@@ -12,7 +12,7 @@
         <div class="text-base-content/60 mb-2 text-center text-sm"><%= t("article_references") %></div>
         <% article.references.each do |reference| %>
           <div class="flex font-sm items-center justify-center space-x-2 text-sm text-base-content/60">
-            <%= image_tag reference.author.avatar_thumb, class: "w-4 h-4 rounded-full" %>
+            <%= render "shared/avatar", user: reference.author, thumb: true, class: "w-4 h-4 rounded-full" %>
             <span><%= reference.title %></span>
           </div>
         <% end %>

--- a/app/views/dashboard/subscribe_articles/_article.html.erb
+++ b/app/views/dashboard/subscribe_articles/_article.html.erb
@@ -1,6 +1,6 @@
 <div id="subscribe_article_<%= dom_id article %>" class="relative flex items-center space-x-4 py-4 border-b border-base-content/10">
   <%= link_to user_article_path(article.author, article), class: "flex flex-1 items-center space-x-2 truncate", data: { turbo_frame: "_top" } do %>
-    <%= image_tag article.author.avatar_thumb, class: "w-8 h-8 rounded-full" %>
+    <%= render "shared/avatar", user: article.author, thumb: true, class: "w-8 h-8 rounded-full" %>
     <span class="truncate"><%= article.title %></span>
   <% end %>
   <div class="">

--- a/app/views/dashboard/subscribe_users/_user.html.erb
+++ b/app/views/dashboard/subscribe_users/_user.html.erb
@@ -1,6 +1,6 @@
 <div id="subscribe_user_<%= dom_id user %>" class="relative flex items-center py-4 justify-between space-x-4 border-b border-base-content/10">
   <%= link_to user_path(user), class: "flex items-center space-x-2 truncate", data: { turbo_frame: "_top" } do %>
-    <%= image_tag user.avatar_thumb, class: "w-8 h-8 rounded-full" %>
+    <%= render "shared/avatar", user:, thumb: true, class: "w-8 h-8 rounded-full" %>
     <span class="truncate max-w-24"><%= user.name %></span>
   <% end %>
   <div class="">

--- a/app/views/home/active_authors.html.erb
+++ b/app/views/home/active_authors.html.erb
@@ -9,7 +9,7 @@
           <%= link_to user_path(user), data: { controller: 'prefetch', turbo_frame: '_top' }, class: "flex items-center space-x-2 truncate" do %>
             <div class="avatar">
               <div class="size-10 rounded-full">
-                <%= image_tag user.avatar_thumb, class: "rounded-full" %>
+                <%= render "shared/avatar", user:, thumb: true, class: "rounded-full" %>
               </div>
             </div>
             <div class="truncate max-w-24"><%= user.name %></div>

--- a/app/views/home/selected_articles.html.erb
+++ b/app/views/home/selected_articles.html.erb
@@ -23,7 +23,7 @@
               <div class="flex items-center space-x-4">
                 <div class="avatar">
                   <div class="size-7 rounded-full">
-                    <%= image_tag article.author.avatar_thumb, class: "rounded-full" %>
+                    <%= render "shared/avatar", user: article.author, thumb: true, class: "rounded-full" %>
                   </div>
                 </div>
                 <span class="text-sm max-w-24 truncate"><%= article.author.name %> </span>

--- a/app/views/pre_orders/_form.html.erb
+++ b/app/views/pre_orders/_form.html.erb
@@ -12,7 +12,7 @@
     <div class="flex items-center space-x-2 mb-1">
       <div class="avatar">
         <div class="size-6 rounded-full">
-          <%= image_tag article.author.avatar_thumb, class: "rounded-full", lazy: true %>
+          <%= render "shared/avatar", user: article.author, thumb: true, class: "rounded-full" %>
         </div>
       </div>
       <span class="text-sm max-w-24 truncate"><%= article.author.name %></span>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -34,7 +34,7 @@
   <% users.each do |user| %>
     <%= link_to user_path(user), 
       class: "cursor-pointer flex items-center space-x-4 py-2 px-4 border-b border-base-content/5 hover:font-bold" do %>
-      <%= image_tag user.avatar_thumb, class: "rounded-lg w-6 h-6" %>
+      <%= render "shared/avatar", user:, thumb: true, class: "rounded-lg w-6 h-6" %>
       <span><%= user.name %></span>
     <% end %>
   <% end %>

--- a/app/views/shared/_avatar.html.erb
+++ b/app/views/shared/_avatar.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (user:, class: nil, thumb: false) %>
+<% image_url = thumb ? user.avatar_image_thumb : user.avatar_image_url %>
+<% css_class = local_assigns[:class].presence || "rounded-full" %>
+<% if image_url.present? %>
+  <%= image_tag image_url, class: css_class, loading: :lazy %>
+<% else %>
+  <div
+    class="<%= css_class %> flex items-center justify-center text-white font-medium select-none avatar-placeholder"
+    data-controller="avatar"
+    data-avatar-seed-value="<%= user.mixin_uuid %>">
+    <%= avatar_initials(user.name) %>
+  </div>
+<% end %>

--- a/app/views/shared/_left_bar.html.erb
+++ b/app/views/shared/_left_bar.html.erb
@@ -76,7 +76,7 @@
             <div class="flex items-center space-x-3 w-full px-4 py-3 rounded-full hover:bg-base-content/5 transition-colors cursor-pointer text-left">
               <div class="avatar flex-shrink-0">
                 <div class="size-10 rounded-full">
-                  <%= image_tag current_user.avatar_thumb, class: "rounded-full" %>
+                  <%= render "shared/avatar", user: current_user, thumb: true, class: "rounded-full" %>
                 </div>
               </div>
               <div class="overflow-hidden flex-1">

--- a/app/views/shared/_tabbar.html.erb
+++ b/app/views/shared/_tabbar.html.erb
@@ -20,7 +20,7 @@
 
     <% if current_user.present? %>
       <% dropdown_button = capture do %>
-        <%= image_tag current_user.avatar_thumb, class: "h-7 w-7 rounded-full" %>
+        <%= render "shared/avatar", user: current_user, thumb: true, class: "h-7 w-7 rounded-full" %>
       <% end %>
       <%= render_dropdown class: 'flex justify-center py-4', button: dropdown_button do %>
         <ul class="menu menu-sm w-52 p-2">

--- a/app/views/users/_user_card.html.erb
+++ b/app/views/users/_user_card.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center justify-between mb-4">
     <div class="avatar">
       <div class="size-20 rounded-full border-2 shadow">
-        <img class="rounded-full" src="<%= user.avatar_url %>" />
+        <%= render "shared/avatar", user:, class: "rounded-full size-full" %>
       </div>
     </div>
     <% if current_user.present? && current_user != user %>

--- a/app/views/users/subscribe_by_users/_user.html.erb
+++ b/app/views/users/subscribe_by_users/_user.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id @user %>_subscribe_by_user_<%= dom_id user %>" class="bg-base-100 sm:rounded-lg relative flex items-center py-2 justify-between mb-4">
   <%= link_to user_path(user), class: "flex items-center space-x-2 truncate", data: { controller: 'prefetch', turbo_frame: "_top" } do %>
-    <%= image_tag user.avatar_thumb, class: "w-10 h-10 rounded-full" %>
+    <%= render "shared/avatar", user:, thumb: true, class: "w-10 h-10 rounded-full" %>
     <span class="truncate max-w-24"><%= user.name %></span>
   <% end %>
   <div class="">

--- a/app/views/users/subscribe_users/_user.html.erb
+++ b/app/views/users/subscribe_users/_user.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id @user %>_subscribe_user_<%= dom_id user %>" class="bg-base-100 sm:rounded-lg relative flex items-center py-2 justify-between mb-4">
   <%= link_to user_path(user), class: "flex items-center space-x-2 truncate", data: { controller: 'prefetch', turbo_frame: "_top" } do %>
-    <%= image_tag user.avatar_thumb, class: "w-10 h-10 rounded-full" %>
+    <%= render "shared/avatar", user:, thumb: true, class: "w-10 h-10 rounded-full" %>
     <span class="truncate max-w-24"><%= user.name %></span>
   <% end %>
   <div class="">

--- a/openspec/changes/archive/2026-06-17-frontend-default-avatar/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-17-frontend-default-avatar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/archive/2026-06-17-frontend-default-avatar/design.md
+++ b/openspec/changes/archive/2026-06-17-frontend-default-avatar/design.md
@@ -1,0 +1,118 @@
+## Context
+
+User avatars resolve through a three-tier chain: ActiveStorage upload → OAuth/Mixin `authorization.avatar_url` → `generated_avatar_url` (dead `api.multiavatar.com` URL keyed by `mixin_uuid`). The same dead URL appears in `MixinNetworkUser` and `NftCollection`.
+
+Approximately 35 ERB views render avatars via raw `image_tag user.avatar_url` / `avatar_thumb` with no shared partial. FlyonUI provides `.avatar` and `.avatar-placeholder` CSS classes already present in the build. The stack uses Stimulus for interactive components and esbuild for bundling.
+
+Server contexts that require a fetchable image URL (Mixin bot notification cards, share-to-Mixin `icon_url`, Grover poster rendering) cannot use a pure CSS/JS placeholder — they need a real HTTP URL.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace dead Multiavatar fallback with a frontend initials + deterministic color placeholder
+- Centralize avatar rendering in a shared partial used across web views
+- Return `nil` from backend avatar methods when no real image exists (no synthetic URLs)
+- Provide a static platform icon fallback for server/external contexts
+- Support CJK and Latin name initials consistently
+- Share avatar rendering logic between Stimulus partial and JS consumers (Tom Select)
+
+**Non-Goals:**
+
+- Server-side SVG generation or new avatar API routes
+- New npm dependencies (DiceBear, etc.)
+- Changing ActiveStorage upload flow or OAuth avatar sync
+- Redesigning avatar upload UX in profile settings
+- NFT collection icon redesign beyond removing dead Multiavatar URL
+
+## Decisions
+
+### 1. Initials + color over identicon library
+
+**Choice:** Initials with HSL background derived from `mixin_uuid` hash.
+
+**Rationale:** Zero bundle size, familiar UX (GitHub/Slack pattern), accessible (text content), no maintenance of external library styles.
+
+**Alternative considered:** `@dicebear/core` — closer to Multiavatar's illustrated look but adds dependency and bundle weight for marginal benefit.
+
+### 2. Split URL methods: web vs external
+
+**Choice:**
+
+- `avatar_image_url` — returns real URL or `nil` (rename/clarify existing `avatar_url` behavior)
+- `avatar_url` — alias that returns `avatar_image_url || asset_url('icon.png')` for backward-compatible external use (notifiers, share, Grover)
+
+**Rationale:** Notifiers and Mixin bot already call `avatar_url` expecting a fetchable URL. A single breaking nil return would break notification cards. External callers keep working; web views migrate to the partial and ignore the icon fallback.
+
+**Alternative considered:** Return nil everywhere and update all notifiers — more breaking, no user-visible benefit.
+
+### 3. Initials in ERB, color in Stimulus
+
+**Choice:** Render initials text server-side from `user.name` in the partial; Stimulus controller sets background color from `mixin_uuid` seed on connect.
+
+**Rationale:** Avoids flash of unstyled gray circle on slow JS load. Initials are display of stored name data, not generated imagery. Color is the distinctive generated element and lives in JS.
+
+**Alternative considered:** Both in JS — purer "frontend only" but worse perceived performance.
+
+### 4. Initials algorithm
+
+**Choice:**
+
+- Split name on whitespace
+- Take first grapheme of first token; if multiple tokens, also take first grapheme of second token
+- Uppercase Latin characters; leave CJK unchanged
+- Max 2 characters
+- Use `Intl.Segmenter` when available; fall back to first code point
+
+**Rationale:** Mixin user base includes CJK names. Single-character CJK initials are standard.
+
+### 5. Color algorithm
+
+**Choice:** FNV-1a or djb2 hash of `mixin_uuid` string → hue 0–359; saturation 65%; lightness 45%. White text (`text-white`).
+
+**Rationale:** Deterministic, stable per user, sufficient visual variety, readable contrast.
+
+### 6. Shared partial API
+
+**Choice:** `render "shared/avatar", user:, class: "size-10"` — partial accepts optional `class` for sizing, optional `thumb: true` to prefer thumb variant when real image exists.
+
+**Rationale:** Matches existing inconsistent size classes at call sites without forcing a size enum.
+
+### 7. JS utility module
+
+**Choice:** `app/javascript/utils/avatar.js` exports `initials(name)`, `colorFromSeed(seed)`, `renderAvatarHtml({ seed, name, className })` for Tom Select and other non-Stimulus consumers.
+
+**Rationale:** Avoid duplicating hash/initials logic in `references_select_controller.js`.
+
+### 8. API contract
+
+**Choice:** When no real avatar, JSON returns `"avatar": null` plus `"avatar_seed": "<mixin_uuid>"` and `"avatar_initials": "TA"`.
+
+**Rationale:** Mobile/API clients can render the same placeholder without reimplementing initials logic if they choose; initials precomputed for convenience.
+
+### 9. Scope includes sibling models
+
+**Choice:** Remove Multiavatar from `User`, `MixinNetworkUser`, and `NftCollection` in the same change. `MixinNetworkUser` already has `DEFAULT_AVATAR_FILE` / platform icon pattern for uploads — reuse for its external fallback.
+
+## Risks / Trade-offs
+
+- **[Risk] Visual regression vs Multiavatar** → Initials are simpler but functional; users with OAuth avatars unaffected
+- **[Risk] Grover poster shows platform icon instead of initials** → Acceptable; poster is share collateral, icon is acceptable fallback. Could revisit with headless JS rendering later
+- **[Risk] ~35 view replacements is mechanical but wide** → Mitigate with shared partial; grep-driven migration
+- **[Risk] API clients break on null avatar** → Document new fields; only affects users without real avatars (currently broken anyway)
+- **[Risk] Notifier tests assert exact avatar_url** → Update tests to expect icon fallback when fixture users lack OAuth avatar
+
+## Migration Plan
+
+1. Add partial, Stimulus controller, and JS utils (no behavior change yet)
+2. Update model methods to remove Multiavatar; add external fallback
+3. Replace view call sites with partial (can be done incrementally but ship together)
+4. Update API jbuilders and JS consumers
+5. Update tests
+6. No database migration required; no feature flag needed
+
+**Rollback:** Revert commit; no data changes to undo.
+
+## Open Questions
+
+- None blocking implementation. Grover initials rendering deferred to a follow-up if posters need branded placeholders instead of platform icon.

--- a/openspec/changes/archive/2026-06-17-frontend-default-avatar/proposal.md
+++ b/openspec/changes/archive/2026-06-17-frontend-default-avatar/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The default user avatar fallback uses `api.multiavatar.com`, which is no longer available. Users without an uploaded avatar or OAuth profile image see broken images across the site, in notifications, and in API responses. We need a self-contained replacement that does not depend on external avatar-generation services.
+
+## What Changes
+
+- Remove `generated_avatar_url` fallback from `User` (and related models that share the same dead URL pattern)
+- Introduce a frontend-only initials + deterministic color placeholder when no real avatar image exists
+- Add a shared `shared/_avatar` partial and Stimulus controller to render avatars consistently across ~35 view call sites
+- Split avatar URL behavior: web UI uses the partial; server contexts that require a fetchable URL (Mixin bot notifications, share links, Grover posters) fall back to the platform icon asset
+- Update JSON API responses to return `null` for avatar when no real image exists, plus seed/name fields for client-side fallback rendering
+- Extract shared avatar utility functions for JS consumers (e.g. Tom Select reference picker)
+
+## Capabilities
+
+### New Capabilities
+
+- `user-default-avatar`: Frontend initials + color placeholder for users without a real avatar image; backend returns nil instead of a generated URL; external contexts use static platform icon fallback
+
+### Modified Capabilities
+
+<!-- No existing openspec specs cover avatar behavior -->
+
+## Impact
+
+- **Models**: `User#avatar_url`, `User#avatar_thumb`, `MixinNetworkUser`, `NftCollection`
+- **Views**: ~35 ERB call sites using `avatar_url` / `avatar_thumb` directly
+- **JavaScript**: New `avatar_controller.js`, shared `utils/avatar.js`; update `references_select_controller.js`
+- **API**: `app/views/api/articles/*.json.jbuilder`, `article_references/index.json.jbuilder` — avatar may be null; new fields added
+- **Notifiers**: Continue using fetchable URL via external fallback helper (platform icon when no real avatar)
+- **Tests**: Notifier tests asserting `avatar_url` in payloads; any controller/view tests depending on multiavatar URLs
+- **Dependencies**: None (no new npm gems)

--- a/openspec/changes/archive/2026-06-17-frontend-default-avatar/specs/user-default-avatar/spec.md
+++ b/openspec/changes/archive/2026-06-17-frontend-default-avatar/specs/user-default-avatar/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: No external avatar generation URL
+
+The system MUST NOT use `api.multiavatar.com` or any other external avatar-generation service as a fallback for user, mixin network user, or NFT collection avatars.
+
+#### Scenario: User without uploaded or OAuth avatar
+
+- **WHEN** a user has no ActiveStorage avatar and no OAuth `avatar_url`
+- **THEN** `User#avatar_image_url` returns `nil`
+- **AND** no multiavatar URL is constructed
+
+#### Scenario: Mixin network user without OAuth avatar
+
+- **WHEN** a `MixinNetworkUser` has no `raw["avatar_url"]`
+- **THEN** its avatar method returns the platform icon asset URL instead of a multiavatar URL
+
+### Requirement: Frontend initials placeholder
+
+The system SHALL render a default avatar placeholder in the web UI consisting of the user's initials on a deterministic background color when no real avatar image URL exists.
+
+#### Scenario: Latin name placeholder
+
+- **WHEN** a user named "Test Author" has no real avatar image
+- **THEN** the avatar partial renders a circle displaying "TA"
+- **AND** the background color is deterministically derived from the user's `mixin_uuid`
+
+#### Scenario: Single-word Latin name
+
+- **WHEN** a user named "Alice" has no real avatar image
+- **THEN** the avatar partial renders a circle displaying "A"
+
+#### Scenario: CJK name placeholder
+
+- **WHEN** a user named "张三" has no real avatar image
+- **THEN** the avatar partial renders a circle displaying "张"
+
+#### Scenario: Real avatar takes precedence
+
+- **WHEN** a user has an ActiveStorage avatar attached
+- **THEN** the avatar partial renders an `<img>` with the storage URL
+- **AND** no initials placeholder is shown
+
+#### Scenario: OAuth avatar takes precedence
+
+- **WHEN** a user has no ActiveStorage avatar but has an OAuth `avatar_url`
+- **THEN** the avatar partial renders an `<img>` with the OAuth URL
+- **AND** no initials placeholder is shown
+
+### Requirement: Deterministic color from seed
+
+The placeholder background color MUST be deterministically computed from the user's `mixin_uuid` so the same user always receives the same color.
+
+#### Scenario: Stable color per user
+
+- **WHEN** the avatar placeholder is rendered twice for the same user
+- **THEN** both renderings produce the same background color
+
+#### Scenario: Different users different colors
+
+- **WHEN** two users with different `mixin_uuid` values have no real avatar
+- **THEN** their placeholder background colors SHOULD differ in most cases
+
+### Requirement: External context static fallback
+
+Server contexts that require a fetchable image URL MUST fall back to the platform icon asset when no real avatar image exists.
+
+#### Scenario: Mixin bot notification icon
+
+- **WHEN** a notifier sends an `icon_url` for a user without a real avatar
+- **THEN** the URL points to the platform icon asset (e.g. `icon.png`)
+- **AND** the URL is fetchable over HTTP
+
+#### Scenario: Share to Mixin icon
+
+- **WHEN** a share action includes `icon_url` for a user without a real avatar
+- **THEN** the URL points to the platform icon asset
+
+### Requirement: API avatar fields
+
+JSON API responses for authors MUST expose avatar state explicitly when no real image exists.
+
+#### Scenario: Author with real avatar in API
+
+- **WHEN** an API response includes an author with an uploaded or OAuth avatar
+- **THEN** `avatar` contains the image URL
+- **AND** `avatar_seed` and `avatar_initials` are present for client convenience
+
+#### Scenario: Author without real avatar in API
+
+- **WHEN** an API response includes an author without a real avatar
+- **THEN** `avatar` is `null`
+- **AND** `avatar_seed` contains the author's `mixin_uuid`
+- **AND** `avatar_initials` contains the computed initials string
+
+### Requirement: Shared avatar rendering
+
+The web UI MUST use a single shared avatar partial for all user avatar renderings instead of direct `image_tag user.avatar_url` calls.
+
+#### Scenario: Consistent partial usage
+
+- **WHEN** any ERB view displays a user avatar
+- **THEN** it renders via the shared avatar partial
+- **AND** sizing is controlled via a passed CSS class local

--- a/openspec/changes/archive/2026-06-17-frontend-default-avatar/tasks.md
+++ b/openspec/changes/archive/2026-06-17-frontend-default-avatar/tasks.md
@@ -1,0 +1,37 @@
+## 1. Frontend avatar utilities
+
+- [x] 1.1 Create `app/javascript/utils/avatar.js` with `initials(name)`, `colorFromSeed(seed)`, and `renderAvatarHtml({ seed, name, className })`
+- [x] 1.2 Create `app/javascript/controllers/avatar_controller.js` — sets background color from seed on connect; register in `controllers/index.js`
+- [x] 1.3 Add `UserHelper#avatar_initials(name)` for ERB partial (mirror JS initials logic)
+
+## 2. Shared avatar partial
+
+- [x] 2.1 Create `app/views/shared/_avatar.html.erb` — renders `<img>` when real URL exists, else initials placeholder with Stimulus data attributes
+- [x] 2.2 Support locals: `user`, `class:` (size/styling), `thumb:` (boolean, default false)
+
+## 3. Backend model changes
+
+- [x] 3.1 Update `User#avatar_image_url` (or refactor `avatar_url`) to return nil when no ActiveStorage/OAuth avatar; remove `generated_avatar_url`
+- [x] 3.2 Update `User#avatar_url` to return `avatar_image_url || ActionController::Base.helpers.asset_url('icon.png')` for external/notifier use
+- [x] 3.3 Update `User#avatar_thumb` to mirror image-url logic without multiavatar fallback
+- [x] 3.4 Remove multiavatar fallback from `MixinNetworkUser#generated_avatar_url`; use platform icon instead
+- [x] 3.5 Remove multiavatar fallback from `NftCollection` icon method; use platform icon instead
+
+## 4. View migration
+
+- [x] 4.1 Replace direct `image_tag user.avatar_url` / `avatar_thumb` calls with `render "shared/avatar"` across all ~35 ERB call sites
+- [x] 4.2 Preserve existing size classes at each call site via `class:` local
+
+## 5. API and JS consumers
+
+- [x] 5.1 Update `app/views/api/articles/show.json.jbuilder` and `index.json.jbuilder` — add `avatar_seed`, `avatar_initials`; return null avatar when no real image
+- [x] 5.2 Update `app/views/article_references/index.json.jbuilder` with same avatar fields
+- [x] 5.3 Update `references_select_controller.js` to use `renderAvatarHtml` when avatar is null
+- [x] 5.4 Update `article_references/_form.html.erb` JSON options if needed for new fields
+
+## 6. Tests and lint
+
+- [x] 6.1 Add unit tests for `UserHelper#avatar_initials` (Latin, CJK, single word)
+- [x] 6.2 Update notifier tests that assert `avatar_url` in payloads
+- [x] 6.3 Add model test: user without avatar returns nil from `avatar_image_url`, icon from `avatar_url`
+- [x] 6.4 Run `bin/rubocop` on touched Ruby files and `bun run lint-check` on touched JS files

--- a/openspec/specs/user-default-avatar/spec.md
+++ b/openspec/specs/user-default-avatar/spec.md
@@ -1,0 +1,102 @@
+### Requirement: No external avatar generation URL
+
+The system MUST NOT use `api.multiavatar.com` or any other external avatar-generation service as a fallback for user, mixin network user, or NFT collection avatars.
+
+#### Scenario: User without uploaded or OAuth avatar
+
+- **WHEN** a user has no ActiveStorage avatar and no OAuth `avatar_url`
+- **THEN** `User#avatar_image_url` returns `nil`
+- **AND** no multiavatar URL is constructed
+
+#### Scenario: Mixin network user without OAuth avatar
+
+- **WHEN** a `MixinNetworkUser` has no `raw["avatar_url"]`
+- **THEN** its avatar method returns the platform icon asset URL instead of a multiavatar URL
+
+### Requirement: Frontend initials placeholder
+
+The system SHALL render a default avatar placeholder in the web UI consisting of the user's initials on a deterministic background color when no real avatar image URL exists.
+
+#### Scenario: Latin name placeholder
+
+- **WHEN** a user named "Test Author" has no real avatar image
+- **THEN** the avatar partial renders a circle displaying "TA"
+- **AND** the background color is deterministically derived from the user's `mixin_uuid`
+
+#### Scenario: Single-word Latin name
+
+- **WHEN** a user named "Alice" has no real avatar image
+- **THEN** the avatar partial renders a circle displaying "A"
+
+#### Scenario: CJK name placeholder
+
+- **WHEN** a user named "张三" has no real avatar image
+- **THEN** the avatar partial renders a circle displaying "张"
+
+#### Scenario: Real avatar takes precedence
+
+- **WHEN** a user has an ActiveStorage avatar attached
+- **THEN** the avatar partial renders an `<img>` with the storage URL
+- **AND** no initials placeholder is shown
+
+#### Scenario: OAuth avatar takes precedence
+
+- **WHEN** a user has no ActiveStorage avatar but has an OAuth `avatar_url`
+- **THEN** the avatar partial renders an `<img>` with the OAuth URL
+- **AND** no initials placeholder is shown
+
+### Requirement: Deterministic color from seed
+
+The placeholder background color MUST be deterministically computed from the user's `mixin_uuid` so the same user always receives the same color.
+
+#### Scenario: Stable color per user
+
+- **WHEN** the avatar placeholder is rendered twice for the same user
+- **THEN** both renderings produce the same background color
+
+#### Scenario: Different users different colors
+
+- **WHEN** two users with different `mixin_uuid` values have no real avatar
+- **THEN** their placeholder background colors SHOULD differ in most cases
+
+### Requirement: External context static fallback
+
+Server contexts that require a fetchable image URL MUST fall back to the platform icon asset when no real avatar image exists.
+
+#### Scenario: Mixin bot notification icon
+
+- **WHEN** a notifier sends an `icon_url` for a user without a real avatar
+- **THEN** the URL points to the platform icon asset (e.g. `icon.png`)
+- **AND** the URL is fetchable over HTTP
+
+#### Scenario: Share to Mixin icon
+
+- **WHEN** a share action includes `icon_url` for a user without a real avatar
+- **THEN** the URL points to the platform icon asset
+
+### Requirement: API avatar fields
+
+JSON API responses for authors MUST expose avatar state explicitly when no real image exists.
+
+#### Scenario: Author with real avatar in API
+
+- **WHEN** an API response includes an author with an uploaded or OAuth avatar
+- **THEN** `avatar` contains the image URL
+- **AND** `avatar_seed` and `avatar_initials` are present for client convenience
+
+#### Scenario: Author without real avatar in API
+
+- **WHEN** an API response includes an author without a real avatar
+- **THEN** `avatar` is `null`
+- **AND** `avatar_seed` contains the author's `mixin_uuid`
+- **AND** `avatar_initials` contains the computed initials string
+
+### Requirement: Shared avatar rendering
+
+The web UI MUST use a single shared avatar partial for all user avatar renderings instead of direct `image_tag user.avatar_url` calls.
+
+#### Scenario: Consistent partial usage
+
+- **WHEN** any ERB view displays a user avatar
+- **THEN** it renders via the shared avatar partial
+- **AND** sizing is controlled via a passed CSS class local

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UserHelperTest < ActionView::TestCase
+  test "avatar_initials returns two initials for multi-word latin names" do
+    assert_equal "TA", avatar_initials("Test Author")
+  end
+
+  test "avatar_initials returns one initial for single-word latin names" do
+    assert_equal "A", avatar_initials("Alice")
+  end
+
+  test "avatar_initials returns first grapheme for cjk names" do
+    assert_equal "张", avatar_initials("张三")
+  end
+
+  test "avatar_initials returns question mark for blank names" do
+    assert_equal "?", avatar_initials("")
+    assert_equal "?", avatar_initials(nil)
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -196,4 +196,22 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.twitter_connected?
     assert_nil user.twitter_profile_url
   end
+
+  test "avatar_image_url returns nil when user has no real avatar" do
+    user = users(:reader_one)
+
+    assert_nil user.avatar_image_url
+  end
+
+  test "avatar_url falls back to platform icon when user has no real avatar" do
+    user = users(:reader_one)
+
+    assert_equal User.default_avatar_url, user.avatar_url
+  end
+
+  test "avatar_image_url returns oauth avatar when present" do
+    user = users(:author)
+
+    assert_equal "https://example.com/avatar.png", user.avatar_image_url
+  end
 end


### PR DESCRIPTION
## Summary

- Remove the dead `api.multiavatar.com` fallback from user, mixin network user, and NFT collection avatar resolution
- Add a shared `shared/_avatar` partial with initials + deterministic color placeholders for users without uploaded or OAuth avatars
- Keep fetchable URLs for external contexts (notifiers, share links, Grover) via platform icon fallback; expose `avatar`, `avatar_seed`, and `avatar_initials` in JSON API responses

## Test plan

- [ ] Sign in as a user without an OAuth avatar and confirm initials placeholder appears across comments, profile, and nav
- [ ] Confirm users with uploaded or Mixin OAuth avatars still show real images
- [ ] Verify Mixin bot notification / share links use platform icon when no real avatar exists
- [ ] Check article reference picker renders initials when author has no avatar URL
- [ ] Run `bin/rails test test/helpers/user_helper_test.rb test/models/user_test.rb`


Made with [Cursor](https://cursor.com)