### PR TITLE
Return 404 for spam scan paths instead of raising exceptions

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -31,7 +31,7 @@ class ArticlesController < ApplicationController
 
   def show
     @article = Article.with_associations.without_drafted.find_by(uuid: params[:uuid])
-    return redirect_back fallback_location: root_path if @article.blank?
+    return render_not_found_page if @article.blank?
 
     authorize @article, :show?
 
@@ -80,7 +80,7 @@ class ArticlesController < ApplicationController
     if @article.present?
       impressionist @article, "share"
     else
-      redirect_back fallback_location: root_path
+      render_not_found_page
     end
   end
 
@@ -149,6 +149,6 @@ class ArticlesController < ApplicationController
 
   def load_article
     @article = current_user.articles.find_by uuid: params[:uuid]
-    redirect_back fallback_location: root_path if @article.blank?
+    render_not_found_page if @article.blank?
   end
 end

--- a/app/controllers/collections/base_controller.rb
+++ b/app/controllers/collections/base_controller.rb
@@ -7,6 +7,6 @@ class Collections::BaseController < ApplicationController
 
   def load_collection
     @collection = Collection.find_by uuid: params[:collection_uuid]
-    redirect_to root_path unless @collection&.listed?
+    render_not_found_page unless @collection&.listed?
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -8,7 +8,7 @@ class CollectionsController < ApplicationController
   def show
     @collection = Collection.listed.find_by uuid: params[:uuid]
     if @collection.blank?
-      redirect_back fallback_location: root_path
+      render_not_found_page
     else
       impressionist @collection
 
@@ -20,6 +20,8 @@ class CollectionsController < ApplicationController
 
   def share
     @collection = Collection.listed.find_by uuid: params[:collection_uuid]
+    return render_not_found_page if @collection.blank?
+
     impressionist @collection, "share"
   end
 end

--- a/app/controllers/concerns/rendering_helper.rb
+++ b/app/controllers/concerns/rendering_helper.rb
@@ -5,6 +5,11 @@ module RenderingHelper
 
   private
 
+  def render_not_found_page
+    @page_title = "404"
+    render "errors/not_found", status: :not_found, formats: [ :html ]
+  end
+
   def render_flash(type, message)
     render turbo_stream: turbo_stream.append(
       "flashes",

--- a/app/controllers/users/base_controller.rb
+++ b/app/controllers/users/base_controller.rb
@@ -7,7 +7,7 @@ class Users::BaseController < ApplicationController
 
   def load_user!
     @user = User.find_by(uid: params[:user_uid])
-    redirect_to root_path if @user.blank?
+    render_not_found_page if @user.blank?
   end
 
   def set_page_meta

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,6 @@ class UsersController < ApplicationController
   def load_user
     uid = params[:uid] || params[:user_id] || params[:full_user_uid] || request.subdomain
     @user = User.find_by(uid:)
-    redirect_back fallback_location: root_path if @user.blank?
+    render_not_found_page if @user.blank?
   end
 end

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -6,4 +6,7 @@ Grover.configure do |config|
   config.use_png_middleware = true
   config.use_jpeg_middleware = true
   config.use_pdf_middleware = false
+  # Only render screenshots for explicit Grover routes (posters, covers).
+  # Without this, spam scans like /articles/foo.jpg hit Grover middleware and raise errors.
+  config.ignore_path = ->(path) { !path.start_with?("/grover/") }
 end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -3,12 +3,24 @@
 require "test_helper"
 
 class ArticlesControllerTest < IntegrationTestCase
-  test "show redirects for draft articles" do
+  test "show returns not found for missing article uuid" do
+    get article_path("微信图片编辑_20240910165925")
+
+    assert_response :not_found
+  end
+
+  test "show returns not found for spam image scan paths" do
+    get "/articles/spam_scan_test.jpg"
+
+    assert_response :not_found
+  end
+
+  test "show returns not found for draft articles" do
     article = articles(:draft)
 
     get user_article_path(article.author, article)
 
-    assert_response :redirect
+    assert_response :not_found
   end
 
   test "show allows guests who may buy to view paywalled article" do

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -17,6 +17,12 @@ class CollectionsControllerTest < IntegrationTestCase
     )
   end
 
+  test "show returns not found for missing collection uuid" do
+    get collection_path(SecureRandom.uuid)
+
+    assert_response :not_found
+  end
+
   test "show succeeds when currency icon_url is missing" do
     @collection.currency.update_column(:raw, @collection.currency.raw.except("icon_url"))
 


### PR DESCRIPTION
## Summary
- Return HTML 404 pages for missing articles, users, and collections instead of `redirect_back`, which bots were triggering on invalid URLs.
- Restrict Grover PNG/JPEG middleware to `/grover/` routes so spam paths like `/articles/foo.jpg` no longer launch headless Chrome and raise `Errno::ENOENT` in production.
- Add `render_not_found_page` helper shared across public resource controllers.

## Test plan
- [x] `bin/rails test test/controllers/articles_controller_test.rb test/controllers/collections_controller_test.rb`
- [x] `bin/rubocop` on changed Ruby files
- [ ] Verify poster generation still works at `/grover/articles/:uuid/poster.png?token=...`


Made with [Cursor](https://cursor.com)