### PR TITLE
docs(benchmarks): list home.active_authors scenarios in README

### DIFF
--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -30,6 +30,8 @@ BENCHMARK_ITERATIONS=10 bin/benchmark article_search.bought
 | `article_search.bought` | Purchased-articles filter |
 | `article_search.subscribed` | Subscribed-authors filter |
 | `article.random_readers` | SQL-sampled reader avatars |
+| `home.active_authors` | Signed-out home active-authors sample (`ORDER BY RANDOM() LIMIT 5`) |
+| `home.active_authors.legacy` | Pre-optimisation shape (`LIMIT 20` + Ruby `sample(5)`) for A/B comparison |
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Add `home.active_authors` and `home.active_authors.legacy` to the Scenarios table in `test/benchmarks/README.md`
- These were registered in `hot_paths.rb` as part of the active-authors SQL-sample optimisation (PR #1759) but were never documented for maintainers browsing the README

Closes #1776.

## Test plan

- [x] Docs-only change; no code touched
- [ ] `bin/benchmark home.active_authors` still runs locally (requires Postgres)


Made with [Cursor](https://cursor.com)