### PR TITLE
Activate per-endpoint rate throttles + shared cache + Retry-After responder

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,74 +3,126 @@
 # https://github.com/rack/rack-attack/blob/6-stable/docs/example_configuration.md
 class Rack::Attack
   ### Configure Cache ###
-
-  # If you don't want to use Rails.cache (Rack::Attack's default), then
-  # configure it here.
   #
-  # Note: The store is only used for throttling (not blocklisting and
-  # safelisting). It must implement .increment and .write like
-  # ActiveSupport::Cache::Store
-
-  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  # Rack::Attack throttles call `cache.increment` on every matching request,
+  # so the store must be shared across all serving processes. We reuse
+  # `Rails.cache` (Solid Cache, DB-backed — see config/environments/*.rb) for
+  # that. Solid Cache implements `#increment` via a read-modify-write lock,
+  # which is consistent (not a Redis-style atomic INCR) but correct for our
+  # single-process Puma config.
+  #
+  # NOTE: if the app is ever scaled to multi-worker forking (`WEB_CONCURRENCY`
+  # > 1), keep this on a shared store — a per-process `MemoryStore` would
+  # multiply every limit below by the worker count.
+  Rack::Attack.cache.store = Rails.cache
 
   ### Throttle Spammy Clients ###
 
-  # If any single client IP is making tons of requests, then they're
-  # probably malicious or a poorly-configured scraper. Either way, they
-  # don't deserve to hog all of the app server's CPU. Cut them off!
-  #
-  # Note: If you're serving assets through rack, those requests may be
-  # counted by rack-attack and this throttle may be activated too
-  # quickly. If so, enable the condition to exclude them from tracking.
-
-  # Throttle all requests by IP (60rpm)
+  # Throttle all requests by IP (60rpm). The catch-all that protects every
+  # unmetered route and absorbs scrapers before they hit the app.
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
   throttle("req/ip", limit: 600, period: 5.minutes, &:ip) if Rails.env.production?
 
   ### Prevent Brute-Force Login Attacks ###
 
-  # The most common brute-force login attack is a brute-force password
-  # attack where an attacker simply tries a large number of emails and
-  # passwords to see if any credentials match.
-  #
-  # Another common method of attack is to use a swarm of computers with
-  # different IPs to try brute-forcing a password for a specific account.
+  # Throttle POST requests to /admin/login by IP address. Admin login is the
+  # most sensitive credential surface and is reachable unauthenticated.
+  throttle("logins/admin/ip", limit: 5, period: 20.seconds) do |req|
+    req.ip if req.path == "/admin/login" && req.post?
+  end
 
-  # Throttle POST requests to /login by IP address
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
-  # throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
-  #   req.ip if req.path == '/login' && req.post?
-  # end
+  # Throttle OAuth callback hits by IP. The callback (`/auth/:provider/callback`)
+  # is the account-takeover / brute-force surface and is also unauthenticated.
+  throttle("oauth/callback/ip", limit: 10, period: 1.minute) do |req|
+    req.ip if %r{\A/auth/[^/]+/callback\z}.match?(req.path)
+  end
 
-  # Throttle POST requests to /login by email param
+  ### Throttle authenticated privileged writes ###
   #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{normalized_email}"
-  #
-  # Note: This creates a problem where a malicious user could intentionally
-  # throttle logins for another user and force their login requests to be
-  # denied, but that's not very common and shouldn't happen to you. (Knock
-  # on wood!)
-  # throttle('logins/email', limit: 5, period: 20.seconds) do |req|
-  #   if req.path == '/login' && req.post?
-  #     # Normalize the email, using the same logic as your authentication process, to
-  #     # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
-  #     req.params['email'].to_s.downcase.gsub(/\s+/, '').presence
-  #   end
-  # end
+  # These are keyed on the signed-in user where possible, falling back to the
+  # request IP so unauthenticated or session-less bursts are still caught. The
+  # session key mirrors `ApplicationController#current_session` — see
+  # `session[:current_session_id]`.
+
+  # API requests keyed by access token (fallback IP). `HTTP_X_ACCESS_TOKEN`
+  # identifies the API caller; without it the request is anonymous and the IP
+  # counter applies.
+  throttle("api/token", limit: 300, period: 5.minutes) do |req|
+    if req.path.start_with?("/api/")
+      req.env["HTTP_X_ACCESS_TOKEN"].presence || "ip:#{req.ip}"
+    end
+  end
+
+  # Comment creation keyed by user (fallback IP).
+  throttle("comments/user", limit: 30, period: 1.minute) do |req|
+    if req.path == "/comments" && req.post?
+      req.env["rack.session"]["current_session_id"].presence || "ip:#{req.ip}"
+    end
+  end
+
+  # Votes (up/down on articles) keyed by user (fallback IP).
+  throttle("votes/user", limit: 200, period: 1.minute) do |req|
+    if req.patch? && req.path.match?(%r{\A/(up|down)voted_articles/})
+      req.env["rack.session"]["current_session_id"].presence || "ip:#{req.ip}"
+    end
+  end
+
+  # Subscribe / block writes keyed by user (fallback IP).
+  throttle("subscribe/user", limit: 60, period: 1.minute) do |req|
+    if req.path.match?(%r{\A/(subscribe_|block_)}) && %w[POST PATCH DELETE].include?(req.request_method)
+      req.env["rack.session"]["current_session_id"].presence || "ip:#{req.ip}"
+    end
+  end
+
+  # Pre-order creation keyed by user (fallback IP). Pre-orders kick off payment
+  # flows; an unbounded burst fills the table and pings the Mixin/MixPay APIs.
+  throttle("pre_orders/user", limit: 10, period: 1.minute) do |req|
+    if req.path == "/pre_orders" && req.post?
+      req.env["rack.session"]["current_session_id"].presence || "ip:#{req.ip}"
+    end
+  end
+
+  # Access-token minting keyed by user (fallback IP). Tokens are long-lived
+  # credentials; cap how fast a single account can mint them.
+  throttle("access_tokens/user", limit: 5, period: 1.hour) do |req|
+    if req.path == "/dashboard/access_tokens" && req.post?
+      req.env["rack.session"]["current_session_id"].presence || "ip:#{req.ip}"
+    end
+  end
+
+  # Search is unauthenticated and runs `ILIKE %query%`; cap the burst rate.
+  throttle("search/ip", limit: 20, period: 1.minute) do |req|
+    req.ip if req.path == "/search" && req.get?
+  end
 
   ### Custom Throttle Response ###
 
-  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
-  # which is just fine.
-  #
-  # If you want to return 503 so that the attacker might be fooled into
-  # believing that they've successfully broken your app (or you just want to
-  # customize the response), then uncomment these lines.
-  # self.throttled_response = lambda do |env|
-  #  [ 503,  # status
-  #    {},   # headers
-  #    ['']] # body
-  # end
+  # Emit a `Retry-After` header, log the throttle event for forensics, and
+  # return JSON for API paths (plain text otherwise). Default Rack::Attack
+  # already returns 429; this makes it actionable for clients and operators.
+  Rack::Attack.throttled_responder = lambda do |req|
+    match_data = req.env["rack.attack.match_data"] || {}
+    now = match_data[:epoch_time] || Time.now.to_i
+    period = match_data[:period] || 60
+    retry_after = period - (now % period)
+
+    Rails.logger.warn(
+      "[Rack::Attack] throttled " \
+        "name=#{req.env["rack.attack.matched"]} " \
+        "count=#{match_data[:count]} " \
+        "period=#{period}s " \
+        "retry_after=#{retry_after}s " \
+        "ip=#{req.ip} " \
+        "ua=#{req.user_agent.inspect} " \
+        "path=#{req.path}"
+    )
+
+    if req.path.start_with?("/api/")
+      body = { error: "rate_limited", retry_after: retry_after }.to_json
+      [ 429, { "Content-Type" => "application/json; charset=utf-8", "Retry-After" => retry_after.to_s }, [ body ] ]
+    else
+      [ 429, { "Content-Type" => "text/plain; charset=utf-8", "Retry-After" => retry_after.to_s }, [ "Retry later\n" ] ]
+    end
+  end
 end

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Rack::Attack lives in the middleware stack, so we exercise it through the
+# full integration stack. The test environment ships with `:null_store` as the
+# cache, which silently no-ops `increment` — so we swap in a `MemoryStore` for
+# Rack::Attack only for the duration of these tests.
+class RackAttackTest < ActionDispatch::IntegrationTest
+  fixtures :all
+
+  setup do
+    @original_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rack::Attack.cache.store = @original_store
+  end
+
+  test "throttles POST /admin/login after 5 attempts in 20s" do
+    5.times { post "/admin/login", params: { name: "x", password: "y" } }
+    # The first 5 must NOT be throttled (they return a redirect for bad creds).
+    assert_not_equal 429, response.status
+
+    post "/admin/login", params: { name: "x", password: "y" }
+    assert_equal 429, response.status
+    assert_not_nil response.headers["Retry-After"]
+  end
+
+  test "throttles OAuth callback after 10 hits in 1min" do
+    10.times { get "/auth/mixin/callback" }
+    get "/auth/mixin/callback"
+    assert_equal 429, response.status
+  end
+
+  test "throttles API by access token and returns JSON" do
+    token = access_tokens(:reader_token)
+    300.times { get "/api/articles", headers: { "HTTP_X_ACCESS_TOKEN" => token.value } }
+    get "/api/articles", headers: { "HTTP_X_ACCESS_TOKEN" => token.value }
+    assert_equal 429, response.status
+    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_equal "rate_limited", JSON.parse(response.body)["error"]
+    assert_not_nil response.headers["Retry-After"]
+  end
+
+  test "throttles search after 20 requests in 1min" do
+    20.times { get "/search", params: { query: "x" } }
+    get "/search", params: { query: "x" }
+    assert_equal 429, response.status
+  end
+end


### PR DESCRIPTION
Closes #1853.

## Summary

Replaces the single global IP throttle (`600 / 5 min`, prod-only) with per-endpoint rules for the previously unmetered privileged surfaces, and points `Rack::Attack.cache.store` at `Rails.cache` (Solid Cache) instead of the default per-process `MemoryStore`.

This is the core fix from the rate-limiting audit in #1847 — the shipped login throttles were still commented out and a long list of privileged write endpoints were completely unmetered.

## Changes

**`config/initializers/rack_attack.rb`** — rewrote the initializer:

- **Cache store**: `Rack::Attack.cache.store = Rails.cache`. Solid Cache implements `#increment` via a read-modify-write lock (not a Redis-style atomic INCR), which is correct for the single-process Puma config. Comment explains the multi-worker caveat. _Correction from #1847:_ that issue recommended adding Redis; this stack deliberately uses Solid Cache (DB-backed) with no Redis anywhere, so this reuses the existing shared store instead of introducing new infra.
- **Per-endpoint throttles** (IP-keyed where unauthenticated, user/session-keyed with IP fallback for authenticated writes):

  | Rule | Limit / period | Key | Matches |
  |---|---|---|---|
  | `logins/admin/ip` | 5 / 20s | IP | `POST /admin/login` |
  | `oauth/callback/ip` | 10 / 1min | IP | `/auth/:provider/callback` |
  | `api/token` | 300 / 5min | access token ⤵ IP | `/api/*` |
  | `comments/user` | 30 / 1min | session ⤵ IP | `POST /comments` |
  | `votes/user` | 200 / 1min | session ⤵ IP | `PATCH /{up,down}voted_articles/*` |
  | `subscribe/user` | 60 / 1min | session ⤵ IP | `/subscribe_*`, `/block_*` |
  | `pre_orders/user` | 10 / 1min | session ⤵ IP | `POST /pre_orders` |
  | `access_tokens/user` | 5 / 1h | session ⤵ IP | `POST /dashboard/access_tokens` |
  | `search/ip` | 20 / 1min | IP | `GET /search` |

- **`throttled_responder`**: emits `Retry-After`, logs a structured `[Rack::Attack] throttled name=… count=… period=… ip=… ua=… path=…` warn, and returns JSON `{ "error": "rate_limited", "retry_after": N }` for `/api/` paths (plain text otherwise). Uses the non-deprecated `throttled_responder=` API (the old `throttled_response=` warns).

**`test/integration/rack_attack_test.rb`** — new. Exercises the middleware stack; swaps in a `MemoryStore` because the test env ships with `:null_store` (which no-ops `increment`). Covers the admin login, OAuth callback, API-token, and search throttles, and asserts the JSON body + `Retry-After` header.

## Validation

- `bin/rails test test/integration/rack_attack_test.rb` — 4 runs, 0 failures.
- `bin/rails test test/integration/ test/controllers/{comments,pre_orders,oauth,api,dashboard}/` — 51 runs, 0 failures (no regressions on throttled endpoints).
- `bin/rubocop` on changed files — clean.
- `bin/rails zeitwerk:check` — all good.
- Boot check: `Rack::Attack.cache.store` resolves to the configured `Rails.cache`; `throttled_responder` is set.

## Notes

- Limits are starting points tuned to current traffic patterns; easy to adjust in one place.
- The `req/ip` global throttle is kept (prod-only) as the catch-all for unmetered routes.
- Search-query length caps + `pg_trgm` indexes are tracked separately in #1854.
- AccessToken count cap is tracked separately in #1855.