### PR TITLE
Cap access tokens per user as defense-in-depth

### DIFF
--- a/app/controllers/dashboard/access_tokens_controller.rb
+++ b/app/controllers/dashboard/access_tokens_controller.rb
@@ -6,7 +6,13 @@ class Dashboard::AccessTokensController < Dashboard::BaseController
   end
 
   def create
-    @access_token = current_user.access_tokens.create access_token_params
+    @access_token = current_user.access_tokens.new access_token_params
+
+    return if @access_token.save
+
+    # Validation failed (e.g. per-user token cap reached). Re-show the form
+    # with the errors inside the modal slot.
+    render :create, status: :unprocessable_entity
   end
 
   def destroy

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -29,6 +29,7 @@ class AccessToken < ApplicationRecord
 
   validates :value, presence: true, uniqueness: true
   validates :memo, presence: true
+  validate :within_per_user_limit, on: :create
 
   after_initialize if: :new_record? do
     self.value = SecureRandom.uuid
@@ -36,7 +37,24 @@ class AccessToken < ApplicationRecord
 
   scope :kept, -> { without_deleted }
 
+  # Defense-in-depth cap behind the `access_tokens/user` throttle. Limits how
+  # many active (non-soft-deleted) tokens a single user can hold — long-lived
+  # credentials that otherwise have no mint-rate bound.
+  def self.per_user_limit
+    20
+  end
+
   def desensitized_value
     value.first(4) + ("*" * 6) + value.last(4)
+  end
+
+  private
+
+  def within_per_user_limit
+    return if user_id.blank?
+
+    return if user.access_tokens.kept.count < self.class.per_user_limit
+
+    errors.add(:base, :token_limit_exceeded, limit: self.class.per_user_limit)
   end
 end

--- a/app/views/dashboard/access_tokens/create.turbo_stream.erb
+++ b/app/views/dashboard/access_tokens/create.turbo_stream.erb
@@ -1,19 +1,30 @@
-<%= turbo_stream.prepend "#{dom_id current_user}_access_tokens_list" do %>
-  <div id="<%= dom_id @access_token %>" class="border-b py-2 px-4">
-    <div class="flex items-center space-x-4">
-      <div class=""><%= @access_token.memo %></div>
-      <div class="flex-1 flex justify-center">
-        <code class="badge badge-soft badge-sm font-mono"><%= @access_token.value %></code>
-      </div>
-      <div class="">
-        <%= button_to t('delete'), 
-          dashboard_access_token_path(@access_token), 
-          method: :delete,
-          class: "btn btn-soft btn-error btn-sm" %>
+<% if @access_token.persisted? %>
+  <%= turbo_stream.prepend "#{dom_id current_user}_access_tokens_list" do %>
+    <div id="<%= dom_id @access_token %>" class="border-b py-2 px-4">
+      <div class="flex items-center space-x-4">
+        <div class=""><%= @access_token.memo %></div>
+        <div class="flex-1 flex justify-center">
+          <code class="badge badge-soft badge-sm font-mono"><%= @access_token.value %></code>
+        </div>
+        <div class="">
+          <%= button_to t('delete'),
+            dashboard_access_token_path(@access_token),
+            method: :delete,
+            class: "btn btn-soft btn-error btn-sm" %>
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
 
-<%= turbo_stream.update "modal" do %>
+  <%= turbo_stream.update "modal" do %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.update "modal" do %>
+    <div class="p-4">
+      <div class="alert alert-error mb-4">
+        <%= safe_join(@access_token.errors.full_messages, tag.br) %>
+      </div>
+      <%= render partial: "form", locals: { } %>
+    </div>
+  <% end %>
 <% end %>

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -2,6 +2,12 @@ en:
   activerecord:
     models:
       article: Article
+    errors:
+      models:
+        access_token:
+          attributes:
+            base:
+              token_limit_exceeded: "You've reached the limit of %{limit} access tokens. Delete an unused one first."
     attributes:
       article:
         title: Title

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -2,6 +2,12 @@ ja:
   created_at: 投稿日
   updated_at: 更新日
   activerecord:
+    errors:
+      models:
+        access_token:
+          attributes:
+            base:
+              token_limit_exceeded: "アクセストークンは%{limit}個が上限です。使わないものを削除してください。"
     models:
       article: 記事
     attributes:

--- a/config/locales/models.zh-CN.yml
+++ b/config/locales/models.zh-CN.yml
@@ -3,6 +3,12 @@ zh-CN:
     models:
       article: 文章
       collection: 合辑
+    errors:
+      models:
+        access_token:
+          attributes:
+            base:
+              token_limit_exceeded: "访问令牌数量已达上限（%{limit} 个），请先删除不再使用的令牌。"
     attributes:
       article:
         title: 标题

--- a/test/controllers/dashboard/access_tokens_controller_test.rb
+++ b/test/controllers/dashboard/access_tokens_controller_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Controller-level coverage for the per-user access-token cap. Uses
+# `ActionController::TestCase` (like PreOrdersCreateControllerTest) so the
+# session can be set directly via `session[:current_session_id]`.
+class Dashboard::AccessTokensControllerTest < ActionController::TestCase
+  tests Dashboard::AccessTokensController
+
+  setup do
+    @user = users(:author)
+    session[:current_session_id] = Session.create!(
+      user: @user,
+      uuid: SecureRandom.uuid,
+      info: { "provider" => "mixin" }
+    ).uuid
+  end
+
+  test "create within the cap succeeds and prepends the token" do
+    assert_difference -> { @user.access_tokens.kept.count }, 1 do
+      post :create, params: { access_token: { memo: "cap test" } }, format: :turbo_stream
+    end
+
+    assert_response :success
+  end
+
+  test "create past the cap returns unprocessable_entity and surfaces the error" do
+    # Fill to the cap (author already has 1 fixture token).
+    (AccessToken.per_user_limit - @user.access_tokens.kept.count).times do
+      AccessToken.create!(user: @user, memo: "filler", value: SecureRandom.uuid)
+    end
+
+    assert_no_difference -> { @user.access_tokens.kept.count } do
+      post :create, params: { access_token: { memo: "one too many" } }, format: :turbo_stream
+    end
+
+    assert_response :unprocessable_entity
+    # The translated error message renders in the modal slot.
+    assert_match(/reached the limit/i, response.body)
+  end
+end

--- a/test/models/access_token_test.rb
+++ b/test/models/access_token_test.rb
@@ -40,4 +40,27 @@ class AccessTokenTest < ActiveSupport::TestCase
 
     assert_predicate token.value, :present?
   end
+
+  test "blocks creation past the per-user cap" do
+    user = users(:reader_one)
+    limit = AccessToken.per_user_limit
+    # Fill up to the limit (the user already has 1 fixture token).
+    (limit - user.access_tokens.kept.count).times do
+      AccessToken.create!(user: user, memo: "filler", value: SecureRandom.uuid)
+    end
+
+    overflow = AccessToken.new(user: user, memo: "one too many", value: SecureRandom.uuid)
+    assert_not overflow.valid?
+    assert_includes overflow.errors.where(:base).map(&:type), :token_limit_exceeded
+  end
+
+  test "soft-deleted tokens don't count toward the cap" do
+    user = users(:reader_one)
+    token = user.access_tokens.kept.first
+    token.soft_delete!
+
+    # After soft-deleting, there should be room to create again.
+    new_token = AccessToken.new(user: user, memo: "replacement", value: SecureRandom.uuid)
+    assert new_token.valid?, "expected soft-deleted tokens not to count toward the cap"
+  end
 end


### PR DESCRIPTION
Closes #1855.

## Summary

`Dashboard::AccessTokensController#create` let a user mint unlimited access tokens (only guard was `authenticate_user!`). This adds a per-user cap (20 active tokens) at the model layer, behind the `access_tokens/user` throttle in #1856.

## Changes

- **`app/models/access_token.rb`** — adds `validate :within_per_user_limit, on: :create`, counting only non-soft-deleted tokens (`user.access_tokens.kept.count`). The limit is exposed via `AccessToken.per_user_limit` (class method, currently `20`), mirroring the `Comment.content_length_limit` pattern already in the codebase.
- **`app/controllers/dashboard/access_tokens_controller.rb`** — `create` now renders the validation errors in the modal slot with `:unprocessable_entity` status when the token fails to save, instead of always rendering the success Turbo Stream.
- **`app/views/dashboard/access_tokens/create.turbo_stream.erb`** — branches on `@access_token.persisted?`: success prepends the token (unchanged); failure re-renders the form with an error alert in the `modal` frame.
- **`config/locales/models.{en,zh-CN,ja}.yml`** — added `activerecord.errors.models.access_token.attributes.base.token_limit_exceeded` with `%{limit}` interpolation.

## Validation

- `bin/rails test` (full suite) — **918 runs, 2268 assertions, 0 failures, 0 errors, 2 skips** (pre-existing).
- New model tests (`test/models/access_token_test.rb`):
  - blocks creation past the cap (asserts `:token_limit_exceeded` error type)
  - soft-deleted tokens don't count toward the cap
- New controller test (`test/controllers/dashboard/access_tokens_controller_test.rb`):
  - create within the cap succeeds (token count increments)
  - create past the cap returns 422 and surfaces the translated error in the modal
- `bin/rubocop` on changed Ruby files — clean. (The Japanese/zh-CN locale files show pre-existing `Lint/Syntax` false positives from rubocop parsing `:` in CJK text as Ruby syntax — same pattern across all locale files; the YAML is valid and Rails loads + interpolates all three translations correctly.)
- `bin/rails zeitwerk:check` — all good.

## Notes

This is the **only** model-layer cap from #1847 Task 5 that warranted action:
- **Comment length cap** — already enforced (1000 chars via `RichTextContent`), redundant.
- **PreOrder uniqueness** — not actionable as written; see the note in #1855.