### PR TITLE
Split Solid Queue workers into critical + default/low pools

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,7 +3,11 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: [critical, default, low]
+    - queues: [critical]
+      threads: <%= ENV.fetch("SOLID_QUEUE_CRITICAL_THREADS", 3).to_i %>
+      processes: <%= ENV.fetch("SOLID_QUEUE_CRITICAL_PROCESSES", 1).to_i %>
+      polling_interval: 0.1
+    - queues: [default, low]
       threads: <%= ENV.fetch("SOLID_QUEUE_THREADS", 5).to_i %>
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1).to_i %>
       polling_interval: 0.1


### PR DESCRIPTION
## Summary

Production previously ran all three queues (, , ) through a **single** worker block in . Bursts of default/low traffic — analytics, poster generation, locale detection, batch distribution, avatar sync — could starve the time-critical payment jobs that sit on the  queue:

-  — sweeps every minute
-  /  — per-event payment callbacks
-  — per-order revenue distribution

This isolates the  queue into its own worker pool so payment traffic is never blocked behind default/low work, and gives + a shared pool with the existing thread/process sizing. **Development and test keep their single shared pool** so  /  are unaffected.

Queue assignments across jobs are unchanged; only the worker topology changes.

| env | before | after |
|-----|--------|-------|
| production |  (1 pool, 5 threads) |  (3 threads) +  (5 threads) |
| development |  (1 pool, 5 threads) | unchanged |
| test |  (1 thread) | unchanged |

Addresses findings **F2, F11, F14** of #1840.

## Why I rejected the rest of #1840 in this PR

Keeping this PR focused on worker isolation. The remaining findings need their own treatment:
- **F1 (SQLite→Postgres for the queue DB)** — ops/infra change (Kamal secrets, a second Postgres, migration), not a code PR. I'll comment on #1840.
- **F3/F6/F9 (Order distribution row lock)** — separate PR (Task 3).
- **F7/F10/F13 (ApplicationJob retry matrix)** — separate PR (Task 5).
- **F4/F8 (silent no-op jobs)** — the premise doesn't fully hold: a nil record makes the job return `nil` and succeed, so it does **not** retry (no retry storm). See comment on #1840.

## Test plan
- [x] `config/queue.yml` renders as valid ERB/YAML
- [x] `production` resolves to two isolated worker pools; `development`/`test` unchanged (verified via `bin/rails runner` parse)
- [ ] CI green