### PR TITLE
Guard Order distribution with row lock and bounded batch sweep

### DIFF
--- a/app/jobs/orders/batch_distribute_job.rb
+++ b/app/jobs/orders/batch_distribute_job.rb
@@ -3,7 +3,22 @@
 class Orders::BatchDistributeJob < ApplicationJob
   queue_as :low
 
+  BATCH_SIZE = 100
+
   def perform
-    Order.paid.find_each(&:distribute_async)
+    # Iterate in bounded batches so a re-scan under the blanket ApplicationJob
+    # retry never re-enqueues the whole backlog in one shot. Isolate per-order
+    # enqueue failures so one bad record can't abort the sweep for every other
+    # paid order; each order still dispatches its own Orders::DistributeJob,
+    # which is row-locked via DistributeService.
+    Order.paid.find_in_batches(batch_size: BATCH_SIZE) do |orders|
+      orders.each do |order|
+        order.distribute_async
+      rescue => e
+        Rails.logger.error "Orders::BatchDistributeJob enqueue failed for order #{order.id}: #{e.class} #{e.message}"
+        Rails.error.report(e, handled: true, severity: :warning,
+                           context: { job: self.class.name, order_id: order.id })
+      end
+    end
   end
 end

--- a/app/services/orders/distribute_service.rb
+++ b/app/services/orders/distribute_service.rb
@@ -12,16 +12,26 @@ class Orders::DistributeService
   end
 
   def call
-    return if @order.completed?
+    # Two paths can dispatch distribution concurrently for the same order:
+    # `after_create_commit :distribute_async` and `Orders::BatchDistributeJob`
+    # (which re-dispatches every paid order every 10 minutes). Without a row
+    # lock both workers can pass the `completed?` guard and attempt to create
+    # the same transfers, racing on the `transfers.trace_id` unique constraint.
+    # Acquire `FOR UPDATE`, then re-check the AASM state under the lock so only
+    # one worker proceeds to completion.
+    @order.class.transaction do
+      @order.lock!
+      return if @order.completed?
 
-    case @order.item
-    when Article
-      distribute_article_order!
-    when Collection
-      distribute_collection_order!
+      case @order.item
+      when Article
+        distribute_article_order!
+      when Collection
+        distribute_collection_order!
+      end
+
+      @order.complete! if @order.paid?
     end
-
-    @order.complete! if @order.paid?
   end
 
   private

--- a/test/jobs/orders/batch_distribute_job_test.rb
+++ b/test/jobs/orders/batch_distribute_job_test.rb
@@ -10,8 +10,8 @@ class Orders::BatchDistributeJobTest < JobTestCase
       order.define_singleton_method(:distribute_async) { called = true }
 
       paid_orders = Order.where(id: order.id)
-      paid_orders.define_singleton_method(:find_each) do |&block|
-        block.call(order)
+      paid_orders.define_singleton_method(:find_in_batches) do |batch_size: 100, &_block|
+        _block.call([ order ])
       end
 
       stub_class_method(Order, :paid, -> { paid_orders }) do
@@ -19,6 +19,29 @@ class Orders::BatchDistributeJobTest < JobTestCase
       end
 
       assert called
+    end
+  end
+
+  test "perform isolates per-order enqueue failures and keeps processing" do
+    with_quill_bot_stub do
+      first = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_one), total: 1.0)
+      second = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_two), total: 1.0)
+
+      second_called = false
+      # The first order's enqueue raises; the second must still be dispatched.
+      first.define_singleton_method(:distribute_async) { raise StandardError, "enqueue failed" }
+      second.define_singleton_method(:distribute_async) { second_called = true }
+
+      paid_orders = [ first, second ]
+      paid_orders.define_singleton_method(:find_in_batches) do |batch_size: 100, &block|
+        block.call(paid_orders)
+      end
+
+      stub_class_method(Order, :paid, -> { paid_orders }) do
+        Orders::BatchDistributeJob.perform_now
+      end
+
+      assert second_called, "second order should be dispatched despite the first raising"
     end
   end
 end

--- a/test/jobs/orders/distribute_job_test.rb
+++ b/test/jobs/orders/distribute_job_test.rb
@@ -3,12 +3,25 @@
 require "test_helper"
 
 class Orders::DistributeJobTest < JobTestCase
+  # DistributeJob re-fetches the order via `Order.find_by`, so per-instance
+  # stubs don't survive. Stub the guard on the class for the test's duration
+  # (the same pattern used in transfer_test.rb / user_authorization_test.rb).
+  ORIGINAL_ALL_TRANSFERS_GENERATED = Order.instance_method(:all_transfers_generated?)
+
+  def with_all_transfers_generated!
+    Order.define_method(:all_transfers_generated?) { true }
+    yield
+  ensure
+    Order.define_method(:all_transfers_generated?, ORIGINAL_ALL_TRANSFERS_GENERATED)
+  end
+
   test "perform calls distribute! on order" do
     with_quill_bot_stub do
       order = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_one), total: 1.0)
 
-      order.define_singleton_method(:all_transfers_generated?) { true }
-      Orders::DistributeJob.perform_now(order.trace_id)
+      with_all_transfers_generated! do
+        Orders::DistributeJob.perform_now(order.trace_id)
+      end
 
       assert order.transfers.exists?
     end

--- a/test/services/orders/distribute_service_article_test.rb
+++ b/test/services/orders/distribute_service_article_test.rb
@@ -337,4 +337,57 @@ class Orders::DistributeServiceArticleTest < ActiveSupport::TestCase
       assert_equal referenced_article.author.mixin_uuid, reference_transfer.opponent_id
     end
   end
+
+  # === Concurrency: row lock guards double distribution ===
+  #
+  # Both `after_create_commit :distribute_async` and
+  # `Orders::BatchDistributeJob` can dispatch distribution for the same order
+  # concurrently. The service must acquire `FOR UPDATE` and re-check
+  # `completed?` under the lock so the transfers are generated only once.
+  ORIGINAL_ALL_TRANSFERS_GENERATED = Order.instance_method(:all_transfers_generated?)
+
+  def with_all_transfers_generated!
+    Order.define_method(:all_transfers_generated?) { true }
+    yield
+  ensure
+    Order.define_method(:all_transfers_generated?, ORIGINAL_ALL_TRANSFERS_GENERATED)
+  end
+
+  test "call is a no-op once the order is already completed" do
+    with_quill_bot_stub do
+      with_all_transfers_generated! do
+        order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+        Orders::DistributeService.call(order)
+        assert order.reload.completed?
+
+        transfers_before = order.transfers.count
+        Orders::DistributeService.call(order)
+        assert_equal transfers_before, order.transfers.count,
+                     "re-running distribution on a completed order must not create transfers"
+      end
+    end
+  end
+
+  test "concurrent calls generate transfers exactly once" do
+    with_quill_bot_stub do
+      with_all_transfers_generated! do
+        order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+
+        threads = Array.new(4) do
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              Orders::DistributeService.call(Order.find(order.id))
+            end
+          end
+        end
+        threads.map(&:join)
+
+        order.reload
+        assert order.completed?, "order should be completed after distribution"
+        # quill_revenue transfer is keyed by a deterministic trace_id derived
+        # from the order, so it must exist exactly once regardless of caller count.
+        assert_equal 1, order.transfers.where(transfer_type: :quill_revenue).count
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Order distribution can be dispatched **concurrently for the same order** from two paths:
- `after_create_commit :distribute_async` (per order create)
- `Orders::BatchDistributeJob` (re-dispatches **every paid order** every 10 minutes)

Both flow through `Orders::DistributeService`, whose only dedup was an **unlocked** `return if completed?` TOCTOU check. Two workers could pass the guard, then race on the `transfers.trace_id` unique constraint — the loser raised `RecordNotUnique`, which the blanket `retry_on StandardError` re-enqueued up to 5×.

### Changes

**`app/services/orders/distribute_service.rb`** — wrap the whole body in `@order.class.transaction { @order.lock!; ... }` (`SELECT ... FOR UPDATE`) and re-check `completed?` under the lock so only one worker generates transfers; the second returns immediately. Moving `complete!` inside the same transaction also makes transfer creation and the AASM transition **atomic** (previously transfers committed, then a guard failure left the order `paid` with orphaned transfers).

**`app/jobs/orders/batch_distribute_job.rb`** — iterate in bounded batches (100) with per-order enqueue isolation so one bad record can't abort the sweep for every other paid order, and a retry never re-enqueues the whole backlog.

### Why the DistributeJobTest stub changed

The job re-fetches the order via `Order.find_by(trace_id:)`, so the test's per-instance `define_singleton_method(:all_transfers_generated?)` was **silently lost**. The transaction change exposed this: previously transfers committed before the guard failure (test "passed"), now the rollback makes the test honest. The stub now lives on the `Order` class for the test's duration (same pattern already used in `transfer_test.rb` / `user_authorization_test.rb`).

Addresses findings **F3, F6, F9** of #1840.

## Test plan
- [x] `Orders::DistributeService`: no-op on completed order; **4 concurrent callers** produce the `quill_revenue` transfer exactly once
- [x] `Orders::BatchDistributeJob`: `find_in_batches` iteration + per-order failure isolation
- [x] `Orders::DistributeJob`: corrected guard stub
- [x] Full `test/jobs/` (37) and `test/services/orders/` + `test/models/order_test.rb` (60) green
- [x] `bin/rubocop` clean on changed files
- [ ] CI green
