### PR TITLE
Replace ApplicationJob blanket retry with a targeted error matrix

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,58 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  retry_on StandardError, wait: :polynomially_longer, attempts: 5
+  MAX_TRANSIENT_RETRIES = 5
+  TRANSIENT_RETRY_WAIT = 5.seconds
 
-  discard_on ActiveJob::DeserializationError
+  # Discard permanent / expected failures — retrying them only fans the same
+  # error out 5×. Each is reported so it surfaces without re-enqueuing.
+  discard_on ActiveJob::DeserializationError,
+             ActiveRecord::RecordNotFound,
+             MixinBot::NotFoundError,
+             MixinBot::UserNotFoundError,
+             MixinBot::UnauthorizedError,
+             MixinBot::ForbiddenError,
+             MixinBot::ValidationError,
+             MixinBot::ConflictError,
+             MixinBot::InsufficientBalanceError,
+             MixinBot::InsufficientPoolError,
+             MixinBot::PinError,
+             MixinBot::InvalidAddressFormatError do |job, error|
+    ApplicationJob.report_discarded(job, error)
+  end
+
+  # Retry transient network / rate-limit / server failures with backoff.
+  retry_on Faraday::TimeoutError,
+           Faraday::ConnectionFailed,
+           OpenSSL::SSL::SSLError,
+           MixinBot::RateLimitError,
+           MixinBot::TransientError,
+           MixinBot::ServerError,
+           wait: :polynomially_longer, attempts: MAX_TRANSIENT_RETRIES
+
+  # Deadlocks deserve a shorter, bounded retry.
+  retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
+
+  # Generic Mixin errors carry an error code that decides retryability
+  # (see MixinBot.retryable?). Route them dynamically instead of blanket
+  # retrying, so a 4xx-style unmapped error is discarded rather than retried.
+  rescue_from MixinBot::ResponseError,
+              MixinBot::RequestError,
+              MixinBot::HttpError do |error|
+    if executions < MAX_TRANSIENT_RETRIES && MixinBot.retryable?(error)
+      retry_job(wait: TRANSIENT_RETRY_WAIT)
+    else
+      ApplicationJob.report_discarded(self, error)
+    end
+  end
+
+  # Centralized discard logging + reporting. Kept resilient so a failure in the
+  # error reporter itself can never raise out of a discard/retry handler.
+  def self.report_discarded(job, error)
+    Rails.logger.error "Discarded #{job.class.name} (#{error.class}): #{error.message}"
+    Rails.error.report(error, handled: true, severity: :warning,
+                       context: { job: job.class.name, arguments: job.arguments.inspect })
+  rescue => e
+    Rails.logger.error "Failed to report discarded job #{job.class.name}: #{e.class}"
+  end
 end

--- a/app/jobs/daily_statistics/generate_job.rb
+++ b/app/jobs/daily_statistics/generate_job.rb
@@ -2,7 +2,12 @@
 
 class DailyStatistics::GenerateJob < ApplicationJob
   queue_as :low
-  retry_on StandardError, attempts: 1
+  # The blanket `retry_on StandardError, attempts: 1` override used to prevent
+  # the old ApplicationJob 5× retry from re-running the whole daily report.
+  # ApplicationJob now only retries known-transient errors (network, rate
+  # limit, deadlocks) and discards permanent ones, so arbitrary StandardError
+  # already fails once — the override is redundant. Transient failures during
+  # report generation now get the base-class backoff instead of a hard stop.
 
   def perform
     DailyStatistic.generate date: Time.current.yesterday

--- a/app/jobs/mixin_messages/send_job.rb
+++ b/app/jobs/mixin_messages/send_job.rb
@@ -2,14 +2,16 @@
 
 class MixinMessages::SendJob < ApplicationJob
   queue_as :default
+
+  # Forbidden / Unauthorized are permanent client errors: ApplicationJob now
+  # discards them with a logged + reported warning in every environment, so
+  # the local rescue (which previously swallowed them silently in production)
+  # is no longer needed.
   def perform(message, bot = "QuillBot")
     if bot == "RevenueBot"
       RevenueBot.api.send_message message
     else
       QuillBot.api.send_message message
     end
-  rescue MixinBot::ForbiddenError, MixinBot::UnauthorizedError => e
-    Rails.logger.error e.inspect
-    raise e if Rails.env.development?
   end
 end

--- a/app/jobs/orders/batch_distribute_job.rb
+++ b/app/jobs/orders/batch_distribute_job.rb
@@ -3,7 +3,22 @@
 class Orders::BatchDistributeJob < ApplicationJob
   queue_as :low
 
+  BATCH_SIZE = 100
+
   def perform
-    Order.paid.find_each(&:distribute_async)
+    # Iterate in bounded batches so a re-scan under the blanket ApplicationJob
+    # retry never re-enqueues the whole backlog in one shot. Isolate per-order
+    # enqueue failures so one bad record can't abort the sweep for every other
+    # paid order; each order still dispatches its own Orders::DistributeJob,
+    # which is row-locked via DistributeService.
+    Order.paid.find_in_batches(batch_size: BATCH_SIZE) do |orders|
+      orders.each do |order|
+        order.distribute_async
+      rescue => e
+        Rails.logger.error "Orders::BatchDistributeJob enqueue failed for order #{order.id}: #{e.class} #{e.message}"
+        Rails.error.report(e, handled: true, severity: :warning,
+                           context: { job: self.class.name, order_id: order.id })
+      end
+    end
   end
 end

--- a/app/services/orders/distribute_service.rb
+++ b/app/services/orders/distribute_service.rb
@@ -12,16 +12,26 @@ class Orders::DistributeService
   end
 
   def call
-    return if @order.completed?
+    # Two paths can dispatch distribution concurrently for the same order:
+    # `after_create_commit :distribute_async` and `Orders::BatchDistributeJob`
+    # (which re-dispatches every paid order every 10 minutes). Without a row
+    # lock both workers can pass the `completed?` guard and attempt to create
+    # the same transfers, racing on the `transfers.trace_id` unique constraint.
+    # Acquire `FOR UPDATE`, then re-check the AASM state under the lock so only
+    # one worker proceeds to completion.
+    @order.class.transaction do
+      @order.lock!
+      return if @order.completed?
 
-    case @order.item
-    when Article
-      distribute_article_order!
-    when Collection
-      distribute_collection_order!
+      case @order.item
+      when Article
+        distribute_article_order!
+      when Collection
+        distribute_collection_order!
+      end
+
+      @order.complete! if @order.paid?
     end
-
-    @order.complete! if @order.paid?
   end
 
   private

--- a/test/fixtures/mixin_network_snapshots.yml
+++ b/test/fixtures/mixin_network_snapshots.yml
@@ -28,11 +28,13 @@
 one:
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+  processed_at: <%= 1.day.ago %>
 
 # column: value
 #
 two:
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+  processed_at: <%= 1.day.ago %>
 
 # column: value

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A concrete job that raises an error identified by a symbol, so we can
+# exercise the ApplicationJob retry/discard matrix without coupling to a real
+# job and without passing non-serializable error objects as arguments.
+class MatrixProbeJob < ApplicationJob
+  ERRORS = {
+    record_not_found: -> { ActiveRecord::RecordNotFound.new("missing") },
+    forbidden: -> { MixinBot::ForbiddenError.new("perm") },
+    unauthorized: -> { MixinBot::UnauthorizedError.new("perm") },
+    not_found: -> { MixinBot::NotFoundError.new("perm") },
+    insufficient_balance: -> { MixinBot::InsufficientBalanceError.new("perm") },
+    timeout: -> { Faraday::TimeoutError.new("timeout") },
+    connection_failed: -> { Faraday::ConnectionFailed.new("conn") },
+    response_500: -> { MixinBot::ResponseError.new("server", code: 500) },
+    response_400: -> { MixinBot::ResponseError.new("client", code: 400) }
+  }.freeze
+
+  def perform(key)
+    raise ERRORS.fetch(key).call
+  end
+end
+
+class ApplicationJobTest < JobTestCase
+  test "discards ActiveRecord::RecordNotFound without retrying" do
+    assert_no_enqueued_jobs do
+      MatrixProbeJob.perform_now(:record_not_found)
+    end
+  end
+
+  test "discards permanent MixinBot client errors without retrying" do
+    [ :forbidden, :unauthorized, :not_found, :insufficient_balance ].each do |key|
+      assert_no_enqueued_jobs do
+        MatrixProbeJob.perform_now(key)
+      end
+    end
+  end
+
+  test "retries Faraday network errors by re-enqueuing" do
+    MatrixProbeJob.perform_now(:timeout)
+    # discard_on swallows; retry_on re-enqueues. TimeoutError is retried, so a
+    # fresh job should be enqueued for the next attempt.
+    assert enqueued_jobs.any? { |j| j["job_class"] == "MatrixProbeJob" },
+           "transient Faraday::TimeoutError should re-enqueue for retry"
+  end
+
+  test "dynamic MixinBot::ResponseError routes by retryability" do
+    clear_enqueued_jobs
+
+    # 500 → retryable → re-enqueue
+    MatrixProbeJob.perform_now(:response_500)
+    assert enqueued_jobs.any? { |j| j["job_class"] == "MatrixProbeJob" },
+           "retryable ResponseError (500) should re-enqueue"
+
+    clear_enqueued_jobs
+
+    # 400 → not retryable → discard, no enqueue
+    MatrixProbeJob.perform_now(:response_400)
+    assert_no_enqueued_jobs
+  end
+end

--- a/test/jobs/orders/batch_distribute_job_test.rb
+++ b/test/jobs/orders/batch_distribute_job_test.rb
@@ -10,8 +10,8 @@ class Orders::BatchDistributeJobTest < JobTestCase
       order.define_singleton_method(:distribute_async) { called = true }
 
       paid_orders = Order.where(id: order.id)
-      paid_orders.define_singleton_method(:find_each) do |&block|
-        block.call(order)
+      paid_orders.define_singleton_method(:find_in_batches) do |batch_size: 100, &_block|
+        _block.call([ order ])
       end
 
       stub_class_method(Order, :paid, -> { paid_orders }) do
@@ -19,6 +19,29 @@ class Orders::BatchDistributeJobTest < JobTestCase
       end
 
       assert called
+    end
+  end
+
+  test "perform isolates per-order enqueue failures and keeps processing" do
+    with_quill_bot_stub do
+      first = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_one), total: 1.0)
+      second = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_two), total: 1.0)
+
+      second_called = false
+      # The first order's enqueue raises; the second must still be dispatched.
+      first.define_singleton_method(:distribute_async) { raise StandardError, "enqueue failed" }
+      second.define_singleton_method(:distribute_async) { second_called = true }
+
+      paid_orders = [ first, second ]
+      paid_orders.define_singleton_method(:find_in_batches) do |batch_size: 100, &block|
+        block.call(paid_orders)
+      end
+
+      stub_class_method(Order, :paid, -> { paid_orders }) do
+        Orders::BatchDistributeJob.perform_now
+      end
+
+      assert second_called, "second order should be dispatched despite the first raising"
     end
   end
 end

--- a/test/jobs/orders/distribute_job_test.rb
+++ b/test/jobs/orders/distribute_job_test.rb
@@ -3,12 +3,25 @@
 require "test_helper"
 
 class Orders::DistributeJobTest < JobTestCase
+  # DistributeJob re-fetches the order via `Order.find_by`, so per-instance
+  # stubs don't survive. Stub the guard on the class for the test's duration
+  # (the same pattern used in transfer_test.rb / user_authorization_test.rb).
+  ORIGINAL_ALL_TRANSFERS_GENERATED = Order.instance_method(:all_transfers_generated?)
+
+  def with_all_transfers_generated!
+    Order.define_method(:all_transfers_generated?) { true }
+    yield
+  ensure
+    Order.define_method(:all_transfers_generated?, ORIGINAL_ALL_TRANSFERS_GENERATED)
+  end
+
   test "perform calls distribute! on order" do
     with_quill_bot_stub do
       order = create_buy_order!(article: articles(:published_paid), buyer: users(:reader_one), total: 1.0)
 
-      order.define_singleton_method(:all_transfers_generated?) { true }
-      Orders::DistributeJob.perform_now(order.trace_id)
+      with_all_transfers_generated! do
+        Orders::DistributeJob.perform_now(order.trace_id)
+      end
 
       assert order.transfers.exists?
     end

--- a/test/services/orders/distribute_service_article_test.rb
+++ b/test/services/orders/distribute_service_article_test.rb
@@ -337,4 +337,57 @@ class Orders::DistributeServiceArticleTest < ActiveSupport::TestCase
       assert_equal referenced_article.author.mixin_uuid, reference_transfer.opponent_id
     end
   end
+
+  # === Concurrency: row lock guards double distribution ===
+  #
+  # Both `after_create_commit :distribute_async` and
+  # `Orders::BatchDistributeJob` can dispatch distribution for the same order
+  # concurrently. The service must acquire `FOR UPDATE` and re-check
+  # `completed?` under the lock so the transfers are generated only once.
+  ORIGINAL_ALL_TRANSFERS_GENERATED = Order.instance_method(:all_transfers_generated?)
+
+  def with_all_transfers_generated!
+    Order.define_method(:all_transfers_generated?) { true }
+    yield
+  ensure
+    Order.define_method(:all_transfers_generated?, ORIGINAL_ALL_TRANSFERS_GENERATED)
+  end
+
+  test "call is a no-op once the order is already completed" do
+    with_quill_bot_stub do
+      with_all_transfers_generated! do
+        order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+        Orders::DistributeService.call(order)
+        assert order.reload.completed?
+
+        transfers_before = order.transfers.count
+        Orders::DistributeService.call(order)
+        assert_equal transfers_before, order.transfers.count,
+                     "re-running distribution on a completed order must not create transfers"
+      end
+    end
+  end
+
+  test "concurrent calls generate transfers exactly once" do
+    with_quill_bot_stub do
+      with_all_transfers_generated! do
+        order = create_buy_order!(article: @article, buyer: @reader_one, total: 1.0)
+
+        threads = Array.new(4) do
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              Orders::DistributeService.call(Order.find(order.id))
+            end
+          end
+        end
+        threads.map(&:join)
+
+        order.reload
+        assert order.completed?, "order should be completed after distribution"
+        # quill_revenue transfer is keyed by a deterministic trace_id derived
+        # from the order, so it must exist exactly once regardless of caller count.
+        assert_equal 1, order.transfers.where(transfer_type: :quill_revenue).count
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`ApplicationJob` previously retried **every** `StandardError` 5× with polynomial backoff. That made permanent client errors (Forbidden, Unauthorized, NotFound, InsufficientBalance, validation, pin) re-fire needlessly — and it **masked latent test bugs** (a monitor job iterating malformed fixture snapshots only "passed" because the `NoMethodError` was swallowed across retries).

Replaces the blanket retry with an explicit matrix:

| Category | Errors | Action |
|----------|--------|--------|
| Permanent / expected | `DeserializationError`, `RecordNotFound`, Mixin `Forbidden`/`Unauthorized`/`NotFound`/`UserNotFound`/`Validation`/`Conflict`/`InsufficientBalance`/`InsufficientPool`/`Pin`/`InvalidAddressFormat` | **discard** (logged + `Rails.error.report`) |
| Transient network / API | `Faraday::TimeoutError`, `Faraday::ConnectionFailed`, `OpenSSL::SSL::SSLError`, Mixin `RateLimit`/`Transient`/`Server` | **retry** polynomial, 5× |
| Deadlock | `ActiveRecord::Deadlocked` | **retry** 5s, 3× |
| Generic Mixin (code-dependent) | `MixinBot::ResponseError`/`RequestError`/`HttpError` | **dynamic** via `MixinBot.retryable?` (5xx retries, 4xx discards) |

### Dropped overrides that existed only to work around the blanket retry
- **`DailyStatistics::GenerateJob`** — `retry_on StandardError, attempts: 1` (arbitrary `StandardError` now fails once by default; transient failures during report generation get the base-class backoff instead of a hard stop). **F10**
- **`MixinMessages::SendJob`** — local `rescue` of `Forbidden`/`Unauthorized`, which silently swallowed auth errors in production. `ApplicationJob` now discards them with a reported warning in every environment. **F13**

### Fixture honesty fix
The two placeholder `mixin_network_snapshots` fixtures had no `processed_at`, so the monitor job's "completes when no delayed snapshots exist" test was iterating them and hitting `nil.amount.positive?`. The test passed **only** because the blanket retry swallowed the `NoMethodError`. Marking them `processed_at` makes the test honest (and it now genuinely exercises the empty path).

Addresses findings **F7, F10, F13** of #1840.

## Why this PR is based on #1860
This branch stacks on top of #1860 because removing the blanket retry exposes the same latent `DistributeJobTest` bug that #1860 fixes (the job re-fetches the order, losing the per-instance stub). Merge #1860 first, then this one.

## Test plan
- [x] New `ApplicationJobTest`: discard of permanent errors, retry of Faraday errors, dynamic `ResponseError` routing by `MixinBot.retryable?`
- [x] Full `test/jobs/` (41) green
- [x] Full test suite (933 runs, 2306 assertions, 0 failures, 2 pre-existing skips)
- [x] `bin/rubocop` clean on changed files
- [x] `bin/rails zeitwerk:check` clean
- [ ] CI green
