### PR TITLE
fix(masthead): reserve mr-24 for the Mixin floating menu

### DIFF
--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -34,7 +34,7 @@
         <%= render "search/form" %>
       </div>
 
-      <div class="ml-auto flex flex-shrink-0 items-center gap-1.5 sm:gap-2">
+      <div class="ml-auto flex flex-shrink-0 items-center gap-1.5 sm:gap-2 <%= 'mr-24' if from_mixin_messenger? %>">
         <% if current_user.present? %>
           <%= link_to new_article_path, class: "btn btn-primary btn-sm rounded-full px-3 font-medium sm:btn-md sm:px-4" do %>
             <span class="i-[tabler--edit] size-4"></span>


### PR DESCRIPTION
## Summary

The July 4 editorial redesign (#1822) replaced `shared/_navbar.html.erb` with `shared/_masthead.html.erb` for the public layout (articles, users, collections, search). The old navbar gated an `mr-24` on its `navbar-end` for the Mixin user agent; the new masthead shipped without that conditional, so the right-side cluster (Write button, notification bell, locale, avatar dropdown) collides with the Mixin nav capsule in immersive mode.

Mirrors the navbar's pattern on the masthead's right cluster so every Mixin-context surface reserves the same 96px gutter for the floating menu.

## Diff

```diff
-      <div class="ml-auto flex flex-shrink-0 items-center gap-1.5 sm:gap-2">
+      <div class="ml-auto flex flex-shrink-0 items-center gap-1.5 sm:gap-2 <%= 'mr-24' if from_mixin_messenger? %>">
```

## Scope

- **Mixin user agent only**: the conditional adds nothing on desktop or ordinary mobile browsers, so existing layouts are untouched.
- **Topbar pages unaffected**: pages that set `content_for :topbar` (article/user/collection show) yield the topbar inside the masthead and already carry their own `mr-24` on the share button — that path is unchanged.
- **Dashboard layout unchanged**: `shared/_navbar.html.erb` keeps its existing `mr-24` and is unaffected.

## References

- Mixin design spec: https://developers.mixin.one/docs/app/design/floating-menu
- Refactor that introduced the masthead: 27c63f98 "Editorial Web3 UI redesign — public pages (#1822)"
- Existing `mr-24` convention: `app/views/shared/_navbar.html.erb:12`, `articles/show.html.erb:66`, `users/show.html.erb:97`, `collections/show.html.erb:44`

🤖 Generated with [Claude Code](https://claude.com/claude-code)