### PR TITLE
[efficiency-improver] perf(admin): eager-load mixin network snapshot index chains

### DIFF
--- a/app/controllers/admin/mixin_network_snapshots_controller.rb
+++ b/app/controllers/admin/mixin_network_snapshots_controller.rb
@@ -65,16 +65,31 @@ module Admin
           }.merge(m: "or")
         ).result
 
-      @pagy, @mixin_network_snapshots = pagy(:countless, mixin_network_snapshots)
+      # Close per-row N+1s walked by `admin/mixin_network_snapshots/_mixin_network_snapshot.html.erb`.
+      # Without this, a 50-row admin page fires ~200 SELECTs for the four
+      # belongs_to + ~250 more for the opponent avatar chain. With the
+      # prime the page renders in ~7 SELECTs regardless of page size.
+      @pagy, @mixin_network_snapshots = pagy(:countless, mixin_network_snapshots.includes(*index_includes))
     end
 
     def show
-      @mixin_network_snapshot = MixinNetworkSnapshot.find params[:id]
+      # Same partial chain as `index` — preload the belongs_to + the opponent
+      # avatar chain so the show view renders flat (1 SELECT for each chain).
+      @mixin_network_snapshot = MixinNetworkSnapshot.includes(*index_includes).find(params[:id])
     end
 
     def process_now
       @mixin_network_snapshot = MixinNetworkSnapshot.find params[:mixin_network_snapshot_id]
       @mixin_network_snapshot.process!
+    end
+
+    private
+
+    # Eager-load chain shared between `index` and `show`. See
+    # `admin/mixin_network_snapshots/_mixin_network_snapshot.html.erb`
+    # for the exact fields walked per row.
+    def index_includes
+      [ :wallet, :opponent_wallet, :currency, { opponent: admin_user_field_preloads } ]
     end
   end
 end

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -32,6 +32,10 @@ BENCHMARK_ITERATIONS=10 bin/benchmark article_search.bought
 | `article.random_readers` | SQL-sampled reader avatars |
 | `home.active_authors` | Signed-out home active-authors sample (`ORDER BY RANDOM() LIMIT 5`) |
 | `home.active_authors.legacy` | Pre-optimisation shape (`LIMIT 20` + Ruby `sample(5)`) for A/B comparison |
+| `dashboard.orders.eager_load` | `Dashboard::OrdersController#index` includes shape (citer + buyer avatar chain) |
+| `dashboard.orders.legacy` | Pre-optimisation shape (no includes) for A/B comparison |
+| `admin.mixin_network_snapshots.eager_load` | `Admin::MixinNetworkSnapshotsController#index` includes shape (wallet + opponent_wallet + currency + opponent avatar chain) |
+| `admin.mixin_network_snapshots.legacy` | Pre-optimisation shape (no includes) for A/B comparison |
 
 ## Limitations
 

--- a/test/benchmarks/hot_paths.rb
+++ b/test/benchmarks/hot_paths.rb
@@ -69,6 +69,39 @@ Benchmarks::Runner.register("dashboard.orders.legacy") do
     .each { |o| o.buyer.avatar_image_thumb; o.citer.author.name if o.citer.is_a?(Article) }
 end
 
+# Mirror of `Admin::MixinNetworkSnapshotsController#index` after PR #1868
+# follow-up: the four belongs_to + the opponent avatar field chain are
+# eagerly loaded in one pass. Without this prime the partial fires
+# ~4 SELECTs/row + ~5 SELECTs/row for the opponent avatar chain.
+Benchmarks::Runner.register("admin.mixin_network_snapshots.eager_load") do
+  MixinNetworkSnapshot
+    .includes(:wallet, :opponent_wallet, :currency, opponent: USER_FIELD_PRELOADS)
+    .order(created_at: :desc)
+    .limit(50)
+    .to_a
+    .each do |s|
+      s.wallet&.uuid
+      s.opponent_wallet&.uuid
+      s.currency&.icon_url
+      s.opponent&.avatar_image_thumb
+    end
+end
+
+# Pre-optimisation shape for direct A/B comparison — the per-row N+1
+# fan-out this PR closes.
+Benchmarks::Runner.register("admin.mixin_network_snapshots.legacy") do
+  MixinNetworkSnapshot
+    .order(created_at: :desc)
+    .limit(50)
+    .to_a
+    .each do |s|
+      s.wallet&.uuid
+      s.opponent_wallet&.uuid
+      s.currency&.icon_url
+      s.opponent&.avatar_image_thumb
+    end
+end
+
 Benchmarks::Runner.setup("article_search.bought") do
   article = articles(:published_paid)
   buyer = users(:reader_one)

--- a/test/controllers/admin/mixin_network_snapshots_controller_test.rb
+++ b/test/controllers/admin/mixin_network_snapshots_controller_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::MixinNetworkSnapshotsControllerTest < ActionController::TestCase
+  tests Admin::MixinNetworkSnapshotsController
+
+  setup do
+    @admin = administrators(:one)
+    # `Admin::BaseController#authenticate_admin!` only checks
+    # `current_admin.blank?`. We bypass it by setting the session directly.
+    @request.session[:current_admin_id] = @admin.id
+  end
+
+  # Admin mixin network snapshots N+1 regression guard.
+  #
+  # `Admin::MixinNetworkSnapshotsController#index` renders
+  # `app/views/admin/mixin_network_snapshots/_mixin_network_snapshot.html.erb`,
+  # which walks up to four belongs_to + a polymorphic avatar chain per row:
+  #   - `wallet` (MixinNetworkUser by user_id)
+  #   - `opponent_wallet` (MixinNetworkUser by opponent_id)
+  #   - `currency` (Currency by asset_id)
+  #   - `opponent` (User by opponent_id/mixin_uuid) — renders the avatar
+  #     field partial, which walks `avatar_image_thumb` (4-5 SELECTs)
+  #
+  # Without the eager-load, a 50-row admin page fires ~200 SELECTs for
+  # the four belongs_to alone and up to ~250 more for the opponent avatar
+  # chain. After the fix: ~7 SELECTs total, regardless of page size.
+  #
+  # This test pins the eager-load shape so a future regression that drops
+  # one of the chains (e.g. someone refactoring the partial or the
+  # controller) is caught immediately.
+
+  test "index_includes preloads wallet, opponent_wallet, currency, and opponent (with avatar chain)" do
+    includes = @controller.send(:index_includes)
+
+    assert_includes includes, :wallet
+    assert_includes includes, :opponent_wallet
+    assert_includes includes, :currency
+    # The opponent chain must be preloaded with the avatar field chain
+    # (authorization + active_storage fan-out) so the partial renders flat.
+    opponent_chain = includes.find { |v| v.is_a?(Hash) && v.key?(:opponent) }
+    assert opponent_chain, "expected opponent in preload chain, got #{includes.inspect}"
+    assert_equal(
+      Admin::BaseController.new.admin_user_field_preloads,
+      opponent_chain[:opponent]
+    )
+  end
+end


### PR DESCRIPTION
Close per-row N+1s in Admin::MixinNetworkSnapshotsController#index
(plus #show, since both render the same partial):

  - wallet, opponent_wallet (MixinNetworkUser by uuid)
  - currency (Currency by asset_id)
  - opponent (User by mixin_uuid) — renders the avatar field partial,
    so preload the shared user_field_preloads chain

Without this, a 50-row admin page fires ~200 SELECTs for the four
belongs_to + ~250 more for the opponent avatar chain. With the prime
the page renders in ~7 SELECTs regardless of page size.

Adds index_includes private helper shared between #index and #show,
plus a regression-guard test pinning the eager-load shape.
Bench scenarios added for direct A/B comparison.

close #1881 
