### PR TITLE
fix: resolve concurrency hazards in payment & ledger flows (#1904, #1905, #1906, #1907, #1908)

### DIFF
--- a/app/controllers/admin/bonuses_controller.rb
+++ b/app/controllers/admin/bonuses_controller.rb
@@ -56,7 +56,7 @@ module Admin
 
     def deliver
       @bonus = Bonus.find_by id: params[:bonus_id]
-      @bonus.deliver! if @bonus&.drafted?
+      @bonus.deliver_with_lock! if @bonus&.drafted?
     end
 
     private

--- a/app/models/bonus.rb
+++ b/app/models/bonus.rb
@@ -49,6 +49,27 @@ class Bonus < ApplicationRecord
     end
   end
 
+  def deliver_with_lock!
+    with_lock do
+      deliver!
+    end
+  end
+
+  def deliver_with_observability!
+    if may_deliver?
+      deliver!
+    else
+      Rails.logger.warn "Bonus##{id} deliver guard failed: state=#{state}"
+      Rails.error.report(
+        StandardError.new("Bonus#deliver guard failed"),
+        handled: true,
+        severity: :info,
+        context: { bonus_id: id, state: state }
+      )
+      false
+    end
+  end
+
   def ensure_transfer_created
     transfer.presence ||
       create_transfer!(

--- a/app/models/concerns/advisory_lockable.rb
+++ b/app/models/concerns/advisory_lockable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AdvisoryLockable
+  extend ActiveSupport::Concern
+
+  def with_advisory_lock(key, &block)
+    lock_id = AdvisoryLockable.lock_id_for(key)
+
+    ActiveRecord::Base.connection_pool.with_connection do |conn|
+      acquired = conn.select_value("SELECT pg_try_advisory_lock(#{lock_id})")
+
+      if acquired
+        begin
+          block.call
+        ensure
+          conn.execute("SELECT pg_advisory_unlock(#{lock_id})")
+        end
+      else
+        Rails.logger.warn "Advisory lock '#{key}' not acquired — operation skipped"
+      end
+    end
+  end
+
+  def self.lock_id_for(key)
+    Digest::SHA256.hexdigest(key.to_s).to_i(16) % (2**63) - 2**63
+  end
+end

--- a/app/models/mixin_network_snapshot.rb
+++ b/app/models/mixin_network_snapshot.rb
@@ -150,7 +150,7 @@ class MixinNetworkSnapshot < ApplicationRecord
   end
 
   def self.last_polled_at
-    Rails.cache.fetch("last_polled_at") do
+    Rails.cache.fetch("last_polled_at", expires_in: 5.minutes, race_condition_ttl: 10.seconds) do
       MixinNetworkSnapshot.order(transferred_at: :desc).first&.transferred_at&.utc&.rfc3339 || Time.current.utc.rfc3339
     end
   end

--- a/app/models/mixin_network_user.rb
+++ b/app/models/mixin_network_user.rb
@@ -29,6 +29,8 @@
 require_dependency "mixin_api/gate"
 
 class MixinNetworkUser < ApplicationRecord
+  include AdvisoryLockable
+
   DEFAULT_AVATAR_FILE = Rails.application.root.join("app/assets/images/#{Settings.icon_file}")
 
   belongs_to :owner, optional: true, inverse_of: false, polymorphic: true
@@ -69,12 +71,14 @@ class MixinNetworkUser < ApplicationRecord
   end
 
   def update_pin!
-    new_pin = SecureRandom.random_number.to_s.split(".").last.first(6)
-    r = mixin_api.update_pin(old_pin: pin, pin: new_pin)
+    with_advisory_lock("mixin_user:#{uuid}:pin_update") do
+      new_pin = SecureRandom.random_number.to_s.split(".").last.first(6)
+      r = mixin_api.update_pin(old_pin: pin, pin: new_pin)
 
-    raise r.inspect if r["data"].blank?
+      raise r.inspect if r["data"].blank?
 
-    update! pin: new_pin
+      update! pin: new_pin
+    end
   end
 
   def initialize_pin!

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -91,6 +91,21 @@ class Order < ApplicationRecord
     end
   end
 
+  def complete_with_observability!
+    if may_complete?
+      complete!
+    else
+      Rails.logger.warn "Order##{id} complete guard failed: all_transfers_generated?=#{all_transfers_generated?}, state=#{state}"
+      Rails.error.report(
+        StandardError.new("Order#complete guard failed"),
+        handled: true,
+        severity: :info,
+        context: { order_id: id, state: state }
+      )
+      false
+    end
+  end
+
   def all_transfers_generated?
     transfers
       .where(wallet_id: payment.wallet_id)

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -127,14 +127,18 @@ class Payment < ApplicationRecord
   def generate_order!
     return unless memo_correct?
 
-    if article.present?
-      generate_article_order!
-    elsif collection.present?
-      generate_collection_order!
-    end
+    with_lock do
+      return if order.present?
 
-    pre_order&.pay! if pre_order&.may_pay?
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+      if article.present?
+        generate_article_order!
+      elsif collection.present?
+        generate_collection_order!
+      end
+
+      pre_order&.pay! if pre_order&.may_pay?
+    end
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, AASM::InvalidTransition => e
     Rails.logger.error e
     reload.generate_refund_transfer!
   end
@@ -228,6 +232,21 @@ class Payment < ApplicationRecord
 
   def ensure_refund_transfer_created
     refund_transfer.present?
+  end
+
+  def refund_with_observability!
+    if may_refund?
+      refund!
+    else
+      Rails.logger.warn "Payment##{id} refund guard failed: state=#{state}"
+      Rails.error.report(
+        StandardError.new("Payment#refund guard failed"),
+        handled: true,
+        severity: :info,
+        context: { payment_id: id, state: state }
+      )
+      false
+    end
   end
 
   def notify_payer

--- a/app/models/splitter.rb
+++ b/app/models/splitter.rb
@@ -27,21 +27,25 @@
 #
 
 class Splitter < MixinNetworkUser
-  def collect_assets
-    assets = mixin_api.assets["data"]
-    assets.each do |asset|
-      next if asset["balance"].to_f.zero?
-      next if transfers.unprocessed.where(asset_id: asset["asset_id"]).present?
+  include AdvisoryLockable
 
-      transfers
-        .create(
-          transfer_type: :default,
-          asset_id: asset["asset_id"],
-          amount: asset["balance"],
-          opponent_id: QuillBot.api.client_id,
-          trace_id: SecureRandom.uuid,
-          memo: "assets collection"
-        )
+  def collect_assets
+    with_advisory_lock("splitter:#{id}:collect") do
+      assets = mixin_api.assets["data"]
+      assets.each do |asset|
+        next if asset["balance"].to_f.zero?
+        next if transfers.unprocessed.where(asset_id: asset["asset_id"]).present?
+
+        transfers
+          .create(
+            transfer_type: :default,
+            asset_id: asset["asset_id"],
+            amount: asset["balance"],
+            opponent_id: QuillBot.api.client_id,
+            trace_id: SecureRandom.uuid,
+            memo: "assets collection"
+          )
+      end
     end
   end
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -114,7 +114,7 @@ class Transfer < ApplicationRecord
     # `source` lookup (which would raise NameError).
     case source_type
     when "Payment"
-      source.refund! if source.may_refund?
+      source.refund_with_observability!
     when "Bonus"
       source.complete! if source.may_complete?
     end
@@ -238,19 +238,19 @@ class Transfer < ApplicationRecord
   end
 
   def self.author_revenue_total_in_usd
-    Rails.cache.fetch("author_revenue_total_in_usd", expires_in: 1.minute) do
+    Rails.cache.fetch("author_revenue_total_in_usd", expires_in: 1.minute, race_condition_ttl: 5.seconds) do
       joins(:currency).where(transfer_type: :author_revenue).sum("amount * currencies.price_usd").to_f.round(4)
     end
   end
 
   def self.reader_revenue_total_in_usd
-    Rails.cache.fetch("reader_revenue_total_in_usd", expires_in: 1.minute) do
+    Rails.cache.fetch("reader_revenue_total_in_usd", expires_in: 1.minute, race_condition_ttl: 5.seconds) do
       joins(:currency).where(transfer_type: :reader_revenue).sum("amount * currencies.price_usd").to_f.round(4)
     end
   end
 
   def self.stats
-    Rails.cache.fetch("transfer_stats", expires_in: 15.minutes) do
+    Rails.cache.fetch("transfer_stats", expires_in: 15.minutes, race_condition_ttl: 30.seconds) do
       cal_stats
     end
   end

--- a/app/services/orders/distribute_service.rb
+++ b/app/services/orders/distribute_service.rb
@@ -30,7 +30,7 @@ class Orders::DistributeService
         distribute_collection_order!
       end
 
-      @order.complete! if @order.paid?
+      @order.complete_with_observability! if @order.paid?
     end
   end
 

--- a/db/migrate/20260714000001_add_compound_unique_index_to_orders.rb
+++ b/db/migrate/20260714000001_add_compound_unique_index_to_orders.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddCompoundUniqueIndexToOrders < ActiveRecord::Migration[8.1]
+  def change
+    add_index :orders,
+      %i[order_type buyer_id item_type item_id],
+      unique: true,
+      where: "order_type IN (0, 3)",
+      name: "idx_orders_buyer_item_type_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_084214) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -360,6 +360,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_084214) do
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"
     t.index ["citer_type", "citer_id"], name: "index_orders_on_citer_type_and_citer_id"
     t.index ["item_type", "item_id"], name: "index_orders_on_item_type_and_item_id"
+    t.index ["order_type", "buyer_id", "item_type", "item_id"], name: "idx_orders_buyer_item_type_unique", unique: true, where: "(order_type = ANY (ARRAY[0, 3]))"
     t.index ["seller_id"], name: "index_orders_on_seller_id"
   end
 

--- a/test/models/concerns/orders/distributable_test.rb
+++ b/test/models/concerns/orders/distributable_test.rb
@@ -39,6 +39,7 @@ class Orders::DistributableTest < ActiveSupport::TestCase
     @author = users(:author)
     @reader_one = users(:reader_one)
     @reader_two = users(:reader_two)
+    @blocked_reader = users(:blocked_reader)
   end
 
   # Order.create! runs through validations, which include a uniqueness check
@@ -112,7 +113,7 @@ class Orders::DistributableTest < ActiveSupport::TestCase
                                          created_at: 3.days.ago)
       older_reward = create_buy_order_raw!(article: @article, buyer: @reader_two, total: 0.5,
                                            created_at: 2.days.ago, order_type: :reward_article)
-      order = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
+      order = create_buy_order_raw!(article: @article, buyer: @blocked_reader, total: 1.0,
                                     created_at: 1.day.ago)
 
       ids = order.early_orders.pluck(:id)
@@ -155,7 +156,7 @@ class Orders::DistributableTest < ActiveSupport::TestCase
                                     created_at: 5.days.ago)
       newer = create_buy_order_raw!(article: @article, buyer: @reader_two, total: 1.0,
                                     created_at: 2.days.ago)
-      order = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
+      order = create_buy_order_raw!(article: @article, buyer: @blocked_reader, total: 1.0,
                                     created_at: 1.day.ago)
 
       assert_equal [ newer.id, older.id ], order.early_orders.pluck(:id)
@@ -192,7 +193,7 @@ class Orders::DistributableTest < ActiveSupport::TestCase
                             created_at: 3.days.ago)
       create_buy_order_raw!(article: @article, buyer: @reader_two, total: 1.0,
                             created_at: 2.days.ago)
-      order = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
+      order = create_buy_order_raw!(article: @article, buyer: @blocked_reader, total: 1.0,
                                     created_at: 1.day.ago)
 
       assert order.early_orders_with_the_same_currency
@@ -220,7 +221,7 @@ class Orders::DistributableTest < ActiveSupport::TestCase
       # Adding early orders after memoization must NOT flip the cached value.
       create_buy_order_raw!(article: @article, buyer: @reader_two, total: 1.0,
                             created_at: 2.days.ago)
-      foreign = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
+      foreign = create_buy_order_raw!(article: @article, buyer: @blocked_reader, total: 1.0,
                                       created_at: 3.days.ago)
       foreign.update_columns(asset_id: SecureRandom.uuid)
 
@@ -242,12 +243,12 @@ class Orders::DistributableTest < ActiveSupport::TestCase
   test "collect_early_readers groups trace_ids by buyer mixin_uuid" do
     with_quill_bot_stub do
       a1 = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
-                                 created_at: 3.days.ago)
+                                 created_at: 3.days.ago, order_type: :reward_article)
       a2 = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
                                  created_at: 2.days.ago)
       b1 = create_buy_order_raw!(article: @article, buyer: @reader_two, total: 1.0,
                                  created_at: 4.days.ago)
-      order = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
+      order = create_buy_order_raw!(article: @article, buyer: @blocked_reader, total: 1.0,
                                     created_at: 1.day.ago)
 
       readers = order.collect_early_readers
@@ -259,7 +260,7 @@ class Orders::DistributableTest < ActiveSupport::TestCase
   test "collect_early_readers preserves the early_orders created_at-desc ordering per buyer" do
     with_quill_bot_stub do
       older = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
-                                    created_at: 5.days.ago)
+                                    created_at: 5.days.ago, order_type: :reward_article)
       newer = create_buy_order_raw!(article: @article, buyer: @reader_one, total: 1.0,
                                     created_at: 2.days.ago)
       order = create_buy_order_raw!(article: @article, buyer: @reader_two, total: 1.0,


### PR DESCRIPTION
Resolves sub-issues of #1894 (Concurrency Hazards in Payment & Ledger Flows):

### Changes

**#1904 — DB-level compound unique index for Order uniqueness validation**
- Adds a partial unique index on `orders` (`order_type, buyer_id, item_type, item_id`) with `WHERE order_type IN (0, 3)` to prevent TOCTOU duplicate buy orders at the database level

**#1905 — Lock-wrapped AASM transitions for Payment, Bonus, and PreOrder**
- Wraps `Payment#generate_order!` with `with_lock` to prevent concurrent insertions
- Adds `Bonus#deliver_with_lock!` to guard the check-then-act pattern in `ensure_transfer_created`
- Adds `AASM::InvalidTransition` to Payment's rescue clause for PreOrder race

**#1906 — AdvisoryLockable concern for cross-process side-effect protection**
- Introduces `AdvisoryLockable` concern using `pg_try_advisory_lock` (non-blocking, session-level)
- Wraps `Splitter#collect_assets` and `MixinNetworkUser#update_pin!` with advisory locks to prevent concurrent duplicate operations across process boundaries

**#1907 — Add race_condition_ttl to Rails.cache.fetch calls**
- Adds `race_condition_ttl` to 4 `Rails.cache.fetch` sites in `Transfer` and `MixinNetworkSnapshot` to prevent cache stampede on cold caches

**#1908 — Instrument AASM event guard failures with observable breadcrumbs**
- Adds `complete_with_observability!`, `refund_with_observability!`, `deliver_with_observability!` wrappers on Order, Payment, and Bonus that log guard failures via `Rails.logger.warn` and `Rails.error.report`

### Verification
- `bin/rails test` — 1015 runs, 2586 assertions, 0 failures (9 pre-existing admin controller errors)
- `bin/rubocop` — 531 files inspected, 0 offenses
- `bin/rails zeitwerk:check` — all good
- `bin/rails db:migrate` — migration applied cleanly