### PR TITLE
fix: use SHA3::Digest::SHA3_256 for sha3 2.x compatibility

### DIFF
--- a/app/models/article_snapshot.rb
+++ b/app/models/article_snapshot.rb
@@ -43,7 +43,7 @@ class ArticleSnapshot < ApplicationRecord
     assign_attributes(
       raw: article.as_json.merge(
         "content" => article.content_body,
-        digest: SHA3::Digest::SHA256.hexdigest(article.content_body)
+        digest: SHA3::Digest::SHA3_256.hexdigest(article.content_body)
       )
     )
   end


### PR DESCRIPTION
sha3 2.x renamed the SHA3::Digest::SHA256 constant to SHA3::Digest::SHA3_256 (with underscores). The production code in app/models/article_snapshot.rb referenced the old name, causing NameError in any code path that triggers ArticleSnapshot#set_defaults.

This regression was introduced by ac74baa0 (update mixin_bot), which pulled in sha3 2.x transitively.

Affected tests (currently broken on main):
- test/controllers/articles_controller_test.rb
- test/controllers/pre_orders_controller_test.rb
- test/models/user_test.rb
- test/services/article_search_service_test.rb
- test/models/daily_statistic_test.rb (PR #1922)

Single-character fix: SHA256 -> SHA3_256.

Verified locally:
- bin/rails zeitwerk:check -> all is good
- bin/rubocop -> 533 files, 0 offenses
- bin/rails test test/controllers/articles_controller_test.rb -> 20 runs, 0 failures, 0 errors
- bin/rails test test/models/daily_statistic_test.rb (after applying PR #1922) -> 22 runs, 63 assertions, 0 failures, 0 errors