### PR TITLE
Add JavaScript behavioral tests in CI and reconcile UI/UX skill routing

### DIFF
--- a/.agents/skills/ui-ux-pro-max/SKILL.md
+++ b/.agents/skills/ui-ux-pro-max/SKILL.md
@@ -356,7 +356,7 @@ Extract key information from user request:
 - **Product type**: Entertainment (social, video, music, gaming), Tool (scanner, editor, converter), Productivity (task manager, notes, calendar), or hybrid
 - **Target audience**: C-end consumer users; consider age group, usage context (commute, leisure, work)
 - **Style keywords**: playful, vibrant, minimal, dark mode, content-first, immersive, etc.
-- **Stack**: React Native (this project's only tech stack)
+- **Stack**: Identify the host project's frontend stack from its manifest, README, or AGENTS.md. This skill's design-system data (colors, typography, UX guidelines, charts) is platform-agnostic; its stack-specific steps and checklists are oriented to mobile/React Native and should be skipped for web projects.
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -436,7 +436,9 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --domain <domain> [-n
 | App interface a11y | `web` | `--domain web "accessibilityLabel touch safe-areas"` |
 | AI prompt / CSS keywords | `prompt` | `--domain prompt "minimalism"` |
 
-### Step 4: Stack Guidelines (React Native)
+### Step 4: Stack Guidelines (React Native host projects only)
+
+> **Scope:** This step applies **only** when the host project is a React Native app. This repository (Quill) is a **server-rendered Rails web app** (Turbo, Stimulus, Tailwind, ERB) — skip Step 4 entirely and rely on `web-design-guidelines` plus the platform-agnostic domains in Step 3.
 
 Get React Native implementation-specific best practices:
 
@@ -474,13 +476,15 @@ python3 skills/ui-ux-pro-max/scripts/search.py "<keyword>" --stack react-native
 
 ## Example Workflow
 
+> The example below assumes a **React Native host project**. For this repository (Quill, a Rails web app), run Steps 1–3 the same way but **skip Step 4** and review output against `web-design-guidelines`.
+
 **User request:** "Make an AI search homepage."
 
 ### Step 1: Analyze Requirements
 - Product type: Tool (AI search engine)
 - Target audience: C-end users looking for fast, intelligent search
 - Style keywords: modern, minimal, content-first, dark mode
-- Stack: React Native
+- Stack: React Native *(example only — always detect the real host stack from AGENTS.md)*
 
 ### Step 2: Generate Design System (REQUIRED)
 
@@ -531,7 +535,7 @@ python3 skills/ui-ux-pro-max/scripts/search.py "fintech crypto" --design-system 
 - Use **multi-dimensional keywords** — combine product + industry + tone + density: `"entertainment social vibrant content-dense"` not just `"app"`
 - Try different keywords for the same need: `"playful neon"` → `"vibrant dark"` → `"content-first minimal"`
 - Use `--design-system` first for full recommendations, then `--domain` to deep-dive any dimension you're unsure about
-- Always add `--stack react-native` for implementation-specific guidance
+- Add `--stack react-native` **only** when the host project is a React Native app (confirm via AGENTS.md); Rails/web projects must skip stack search
 
 ### Common Sticking Points
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,8 +72,9 @@ jobs:
           sudo apt-get -yyq install libpq-dev
           # Install Chrome for system tests (Selenium WebDriver 4.x auto-manages the matching driver)
           if ! command -v google-chrome-stable &>/dev/null; then
+            sudo apt-get -yyq install wget
             wget -q -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            sudo apt-get -yyq install /tmp/chrome.deb || true
+            sudo apt-get -yyq install /tmp/chrome.deb
           fi
 
       - name: CI

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,7 +68,13 @@ jobs:
           bun install
 
       - name: Install system dependencies
-        run: sudo apt-get -yyq install libpq-dev
+        run: |
+          sudo apt-get -yyq install libpq-dev
+          # Install Chrome for system tests (Selenium WebDriver 4.x auto-manages the matching driver)
+          if ! command -v google-chrome-stable &>/dev/null; then
+            wget -q -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo apt-get -yyq install /tmp/chrome.deb || true
+          fi
 
       - name: CI
         run: bin/ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,17 @@ bun run build:css
 - **JS**: Stimulus controllers in `app/javascript/controllers/`; entry `app/javascript/application.js`
 - **Comments**: sparse; schema comments auto-generated on models
 
+## UI/UX Skills
+
+This project is a **server-rendered Rails web app** (Turbo, Stimulus, Tailwind, ERB). Two UI/UX skills are installed but target different platforms:
+
+| When to use | Skill | Scope |
+|---|---|---|
+| **Web UI review, accessibility audit, or web interface compliance** | `web-design-guidelines` | Desktop/web — matches this project's stack |
+| **Mobile-app design system generation** (colors, typography, chart selection, UX patterns) | `ui-ux-pro-max` | Mobile/React-Native-oriented design intelligence DB — **do not use its stack-specific steps or checklist for this Rails web project** |
+
+**Routing rule:** For any UI review, accessibility check, or web UX work in this repository, use `web-design-guidelines`. The `ui-ux-pro-max` skill provides platform-agnostic design-system data (color palettes, font pairings, UX guidelines) that may supplement design decisions, but its stack examples (`react-native-vector-icons`, `hitSlop`, `safe-area`, bottom tab bars) do not apply to this web stack.
+
 ## Testing Conventions
 
 - **Location**: `test/` mirrors `app/` (`test/models/`, `test/controllers/`, `test/jobs/`, `test/notifiers/`)

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -8,11 +8,11 @@ CI.run do
   step "Style: Ruby", "bin/rubocop"
 
   step "Style: JavaScript", "bun run lint-check"
+  step "Tests: JavaScript", "bun run test:js"
   step "Tests: Rails", "bin/rails test"
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 
-  # Optional: Run system tests
-  # step "Tests: System", "bin/rails test:system"
+  step "Tests: System", "bin/rails test:system"
 
   # Optional: set a green GitHub commit status to unblock PR merge.
   # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css",
     "build": "node esbuild.config.js",
     "build:css:watch": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --watch",
-    "build:watch": "node esbuild.config.js --watch"
+    "build:watch": "node esbuild.config.js --watch",
+    "test": "bun test",
+    "test:js": "bun test test/javascript/"
   },
   "version": "0.1.0",
   "dependencies": {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,5 +3,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [ 1400, 1400 ]
+  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
 end

--- a/test/javascript/article_revenue.test.js
+++ b/test/javascript/article_revenue.test.js
@@ -1,0 +1,132 @@
+import { test, expect, describe } from "bun:test";
+import ArticleRevenueController from "../../app/javascript/controllers/article_revenue_controller";
+
+// Create a controller-like object that shares the prototype methods so we can
+// exercise the revenue-split math without booting Stimulus or a real DOM.
+// Each `has*Target` gate and `*Target.value` mirrors the form fields the
+// production template binds.
+function makeRevenueController(ratios) {
+  const c = Object.create(ArticleRevenueController.prototype);
+
+  const targets = {
+    readersRevenueRatio: { value: String(ratios.readers ?? 0.4) },
+    authorRevenueRatio: { value: String(ratios.author ?? 0.5) },
+    collectionRevenueRatio: { value: String(ratios.collection ?? 0) },
+    referenceRevenueRatio: { value: String(ratios.references ?? 0) },
+    revenueSummary: { innerHTML: "", classList: { toggle: () => {} } },
+  };
+
+  for (const [name, target] of Object.entries(targets)) {
+    c[`has${name[0].toUpperCase()}${name.slice(1)}Target`] = true;
+    c[`${name}Target`] = target;
+  }
+
+  return c;
+}
+
+describe("ArticleRevenueController — validateRevenueSplit", () => {
+  test("passes for the default 40/10/50 split (readers 40%, platform 10%, author 50%)", () => {
+    const c = makeRevenueController({ readers: 0.4, author: 0.5 });
+    expect(c.validateRevenueSplit()).toBe(true);
+  });
+
+  test("passes when references and collection are included and all ratios sum to 100%", () => {
+    const c = makeRevenueController({
+      readers: 0.3,
+      author: 0.4,
+      collection: 0.1,
+      references: 0.1,
+    });
+    // platform 0.1 + readers 0.3 + author 0.4 + collection 0.1 + references 0.1 = 1.0
+    expect(c.validateRevenueSplit()).toBe(true);
+  });
+
+  test("fails when ratios do not sum to 100%", () => {
+    const c = makeRevenueController({
+      readers: 0.4,
+      author: 0.3, // platform 0.1 + 0.4 + 0.3 = 0.8, missing 0.2
+    });
+    expect(c.validateRevenueSplit()).toBe(false);
+  });
+
+  test("passes within the 0.01 tolerance boundary", () => {
+    const c = makeRevenueController({
+      readers: 0.4,
+      author: 0.499, // 0.1 + 0.4 + 0.499 = 0.999, within 0.01 of 1.0
+    });
+    expect(c.validateRevenueSplit()).toBe(true);
+  });
+
+  test("fails just outside the 0.01 tolerance boundary", () => {
+    const c = makeRevenueController({
+      readers: 0.4,
+      author: 0.489, // 0.1 + 0.4 + 0.489 = 0.989, diff = 0.011 > 0.01
+    });
+    expect(c.validateRevenueSplit()).toBe(false);
+  });
+});
+
+describe("ArticleRevenueController — calAuthorRevenueRatio", () => {
+  test("author = 0.9 − readers − references − collection (default split)", () => {
+    const c = makeRevenueController({
+      readers: 0.4,
+      author: 0,
+      collection: 0,
+      references: 0,
+    });
+    c.calAuthorRevenueRatio();
+
+    expect(parseFloat(c.authorRevenueRatioTarget.value)).toBe(0.5);
+  });
+
+  test("author decreases as readers increases", () => {
+    const c = makeRevenueController({
+      readers: 0.6,
+      author: 0,
+      collection: 0,
+      references: 0,
+    });
+    c.calAuthorRevenueRatio();
+
+    expect(parseFloat(c.authorRevenueRatioTarget.value)).toBe(0.3);
+  });
+
+  test("author accounts for collection and reference cuts", () => {
+    const c = makeRevenueController({
+      readers: 0.3,
+      author: 0,
+      collection: 0.05,
+      references: 0.05,
+    });
+    c.calAuthorRevenueRatio();
+
+    // 0.9 - 0.3 - 0.05 - 0.05 = 0.5
+    expect(parseFloat(c.authorRevenueRatioTarget.value)).toBe(0.5);
+  });
+});
+
+describe("ArticleRevenueController — revenueSummaryTemplate", () => {
+  test("renders the default split as percentages with 'you', 'early readers', 'platform'", () => {
+    const c = makeRevenueController({});
+    const html = c.revenueSummaryTemplate(0.5, 0.4, 0.1, 0, 0);
+
+    expect(html).toContain("50%");
+    expect(html).toContain("you");
+    expect(html).toContain("40%");
+    expect(html).toContain("early readers");
+    expect(html).toContain("10%");
+    expect(html).toContain("platform");
+    // No collection or references at zero
+    expect(html).not.toContain("collection");
+    expect(html).not.toContain("references");
+  });
+
+  test("includes collection and references when non-zero", () => {
+    const c = makeRevenueController({});
+    const html = c.revenueSummaryTemplate(0.4, 0.3, 0.1, 0.1, 0.1);
+
+    expect(html).toContain("10%");
+    expect(html).toContain("collection");
+    expect(html).toContain("references");
+  });
+});

--- a/test/javascript/currency.test.js
+++ b/test/javascript/currency.test.js
@@ -1,0 +1,119 @@
+import { test, expect, describe } from "bun:test";
+import Currency from "../../app/javascript/controllers/article_form/currency";
+
+// Minimal mock that satisfies the Stimulus target contract without a DOM.
+// Each `has*Target` gate and `*Target` value mirrors how the production
+// controller exposes its form fields to the Currency module.
+function makeMockController(overrides = {}) {
+  const controller = {
+    currencyPriceUsdValue: 0,
+    hasPriceUsdInputTarget: true,
+    priceUsdInputTarget: { value: "0" },
+    hasPriceCryptoTarget: true,
+    priceCryptoTarget: { value: "" },
+    hasPriceCryptoDisplayTarget: true,
+    priceCryptoDisplayTarget: { innerText: "" },
+    hasCurrencySymbolTarget: true,
+    currencySymbolTarget: { textContent: " BTC", innerText: "" },
+    element: { querySelector: () => null },
+    readiness: { update: () => {} },
+    autosave: { queueAutosave: () => {} },
+    ...overrides,
+  };
+  return controller;
+}
+
+describe("Currency — calCryptoFromUsd", () => {
+  test("converts USD to crypto by dividing by the asset unit price", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 50_000, // 1 BTC = $50,000
+      priceUsdInputTarget: { value: "100" },
+    });
+
+    const currency = new Currency(controller);
+    currency.calCryptoFromUsd();
+
+    // 100 / 50000 = 0.002, rounded to 8 decimals
+    expect(controller.priceCryptoTarget.value).toBe(0.002);
+  });
+
+  test("rounds to 8 decimal places", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 3, // 1 token = $3
+      priceUsdInputTarget: { value: "1" },
+    });
+
+    const currency = new Currency(controller);
+    currency.calCryptoFromUsd();
+
+    // 1 / 3 = 0.33333333… → toFixed(8) = "0.33333333" → parseFloat = 0.33333333
+    expect(controller.priceCryptoTarget.value).toBe(0.33333333);
+  });
+
+  test("updates the visible crypto display with the symbol", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 50_000,
+      priceUsdInputTarget: { value: "250" },
+      currencySymbolTarget: { textContent: " BTC", innerText: "" },
+    });
+
+    const currency = new Currency(controller);
+    currency.calCryptoFromUsd();
+
+    // 250 / 50000 = 0.005
+    expect(controller.priceCryptoDisplayTarget.innerText).toBe("0.005 BTC");
+  });
+
+  test("skips when the asset has no USD price set", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 0,
+      priceUsdInputTarget: { value: "100" },
+    });
+
+    const currency = new Currency(controller);
+    currency.calCryptoFromUsd();
+
+    // No crypto value should be written
+    expect(controller.priceCryptoTarget.value).toBe("");
+  });
+
+  test("skips when the USD input is zero or negative", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 50_000,
+      priceUsdInputTarget: { value: "0" },
+    });
+
+    const currency = new Currency(controller);
+    currency.calCryptoFromUsd();
+
+    expect(controller.priceCryptoTarget.value).toBe("");
+  });
+
+  test("skips when the USD input is not a number", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 50_000,
+      priceUsdInputTarget: { value: "abc" },
+    });
+
+    const currency = new Currency(controller);
+    currency.calCryptoFromUsd();
+
+    expect(controller.priceCryptoTarget.value).toBe("");
+  });
+});
+
+describe("Currency — setPricePreset", () => {
+  test("sets the USD input to the preset and recalculates crypto", () => {
+    const controller = makeMockController({
+      currencyPriceUsdValue: 50_000,
+      priceUsdInputTarget: { value: "0" },
+    });
+
+    const currency = new Currency(controller);
+    currency.setPricePreset({ params: { preset: 9.99 } });
+
+    expect(controller.priceUsdInputTarget.value).toBe("9.99");
+    // 9.99 / 50000 = 0.0001998 → toFixed(8)
+    expect(controller.priceCryptoTarget.value).toBe(0.0001998);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses two harness findings from the `/better-harness` review of the coding-agent operating system:

1. **JS verification gap** — 47 Stimulus controllers and 56 JS source files shipped with zero JavaScript behavioral tests and no JS test runner; system tests were commented out in CI. JavaScript changes (including payment, pre-order, autosave UX) were guarded only by Prettier formatting.

2. **UI/UX skill routing mismatch** — Two UI/UX skills overlap on the review trigger with no routing rule, and `ui-ux-pro-max` unconditionally asserted React Native as this project's stack.

## Changes

### JavaScript verification surface (zero new dependencies)

- **`package.json`** — added `test` and `test:js` scripts using bun's built-in test runner
- **`test/javascript/currency.test.js`** — 7 behavioral tests for the USD-to-crypto conversion math (`calCryptoFromUsd`): conversion accuracy, 8-decimal rounding, display rendering, and edge cases (no price, zero/negative, NaN, presets)
- **`test/javascript/article_revenue.test.js`** — 10 behavioral tests for the revenue split: `validateRevenueSplit` (default 40/10/50, multi-party, sum ≠ 100%, tolerance boundary), `calAuthorRevenueRatio` (author = 0.9 − readers − references − collection), and `revenueSummaryTemplate`

### CI wiring

- **`config/ci.rb`** — added `Tests: JavaScript` step (`bun run test:js`); re-enabled system tests (`bin/rails test:system`)
- **`test/application_system_test_case.rb`** — switched from `:chrome` to `:headless_chrome` (standard CI practice)
- **`.github/workflows/check.yml`** — installs `google-chrome-stable` for Selenium WebDriver 4.x (which auto-manages the matching driver)

### UI/UX skill routing

- **`AGENTS.md`** — new `## UI/UX Skills` section with a routing table: `web-design-guidelines` for web UI review/accessibility (matches this Rails stack); `ui-ux-pro-max` flagged as mobile/React-Native-oriented
- **`.agents/skills/ui-ux-pro-max/SKILL.md`** — removed three unconditional React Native assertions (Step 4 heading, example workflow, "always add `--stack react-native`" tip) and qualified them as RN-host-only with explicit scope notices

## Validation

- [x] `bun run test:js` passes (17 tests)
- [x] `bun run lint-check` (Prettier) passes
- [x] `bin/rubocop` on changed Ruby files passes
- [x] AGENTS.md names `web-design-guidelines` as the web-review skill
- [x] `ui-ux-pro-max` no longer asserts React Native as this project's stack