### PR TITLE
ci: make dependency installs reproducible

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bundle install
-          bun install
+          bundle install --jobs 4 --retry 3
+          bun install --frozen-lockfile
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Summary

Implements #1969.

Two small flags on the existing install step in `.github/workflows/check.yml`:

- `bun install --frozen-lockfile` — fail CI on lockfile drift instead of silently rewriting `bun.lock` from `package.json`.
- `bundle install --jobs 4 --retry 3` — parallelize gem installation and retry transient network/git failures.

## Why

The check workflow was running unconstrained `bun install`, which lets `package.json` / `bun.lock` drift in CI without anyone noticing. The Bundler install was also serialized and had no retry, so a flaky mirror could fail an otherwise-green run.

## Trade-offs

`bun.lock` must now stay in sync with `package.json` (intentional — surface drift in CI rather than letting it ship). No runtime or application dependencies change.

## Verification

- Ruby Psych parses `check.yml` cleanly.
- `bun install --frozen-lockfile` is a documented Bun flag (verified in `bun install --help`).
- `bundle install --jobs 4 --retry 3` matches documented Bundler flags; `--retry` retries failed network/git requests.

Refs #1969